### PR TITLE
Change the attribution text from a single string value to a collection

### DIFF
--- a/src/main/java/org/spdx/library/model/SpdxFile.java
+++ b/src/main/java/org/spdx/library/model/SpdxFile.java
@@ -98,7 +98,7 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 		
 		// optional parameters - SpdxItem
 		setLicenseComments(spdxFileBuilder.licenseComments);
-		setAttributionText(spdxFileBuilder.attributionText);
+		getAttributionText().addAll(spdxFileBuilder.attributionText);
 		
 		// optional parameters - SpdxFile
 		Iterator<Checksum> iter = spdxFileBuilder.checksums.iterator();
@@ -351,7 +351,7 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 		
 		// optional fields - SpdxItem
 		String licenseComments = null;
-		String attributionText = null;
+		Collection<String> attributionText = new ArrayList<String>();
 		
 		// optional fields - SpdxFile
 		Collection<Checksum> checksums = new ArrayList<Checksum>();
@@ -524,8 +524,20 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 		 * @param attributionText Attribution text for the file
 		 * @return this to continue the build
 		 */
-		public SpdxFileBuilder setAttributionText(@Nullable String attributionText) {
+		public SpdxFileBuilder setAttributionText(Collection<String> attributionText) {
+			Objects.requireNonNull(attributionText, "Attribution text collection can not be null");
 			this.attributionText = attributionText;
+			return this;
+		}
+		
+		/**
+		 * Add attribution to the attribution text collection
+		 * @param attribution
+		 * @return
+		 */
+		public SpdxFileBuilder addAttributionText(String attribution) {
+			Objects.requireNonNull(attribution, "Attribution text can not be null");
+			this.attributionText.add(attribution);
 			return this;
 		}
 		

--- a/src/main/java/org/spdx/library/model/SpdxItem.java
+++ b/src/main/java/org/spdx/library/model/SpdxItem.java
@@ -135,21 +135,11 @@ public abstract class SpdxItem extends SpdxElement {
 	}
 	
 	/**
-	 * @return attribution text, empty string if no 
+	 * @return attribution text collection
 	 * @throws InvalidSPDXAnalysisException
 	 */
-	public Optional<String> getAttributionText() throws InvalidSPDXAnalysisException {
-		return getStringPropertyValue(SpdxConstants.PROP_ATTRIBUTION_TEXT);
-	}
-	
-	/**
-	 * @param attributionText Attribution text to set
-	 * @return myself - so you can chain setters
-	 * @throws InvalidSPDXAnalysisException
-	 */
-	public SpdxItem setAttributionText(@Nullable String attributionText) throws InvalidSPDXAnalysisException {
-		setPropertyValue(SpdxConstants.PROP_ATTRIBUTION_TEXT, attributionText);
-		return this;
+	public Collection<String> getAttributionText() throws InvalidSPDXAnalysisException {
+		return getStringCollection(SpdxConstants.PROP_ATTRIBUTION_TEXT);
 	}
 	
 	@Override 

--- a/src/main/java/org/spdx/library/model/SpdxPackage.java
+++ b/src/main/java/org/spdx/library/model/SpdxPackage.java
@@ -97,7 +97,7 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		// optional parameters - SpdxItem
 		setLicenseComments(spdxPackageBuilder.licenseComments);
 		getLicenseInfoFromFiles().addAll(spdxPackageBuilder.licenseInfosFromFile);
-		setAttributionText(spdxPackageBuilder.attributionText);
+		getAttributionText().addAll(spdxPackageBuilder.attributionText);
 		
 		// optional parameters - SpdxPackage
 		Iterator<Checksum> iter = spdxPackageBuilder.checksums.iterator();
@@ -705,7 +705,7 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		// optional fields - SpdxItem
 		Collection<AnyLicenseInfo> licenseInfosFromFile; // required if isFilesAnalyzed is true
 		String licenseComments = null;
-		String attributionText = null;
+		Collection<String> attributionText = new ArrayList<String>();
 		
 		// optional fields - SpdxPackage
 		Collection<Checksum> checksums = new ArrayList<Checksum>();
@@ -1006,8 +1006,19 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		 * @param attributionText Attribution text for the package
 		 * @return this to continue the build
 		 */
-		public SpdxPackageBuilder setAttributionText(String attributionText) {
+		public SpdxPackageBuilder setAttributionText(Collection<String> attributionText) {
+			Objects.requireNonNull(attributionText, "Attribution text collection can not be null");
 			this.attributionText = attributionText;
+			return this;
+		}
+		
+		/**
+		 * @param attribution attribution to add to the attribution text
+		 * @return this to continue the build
+		 */
+		public SpdxPackageBuilder addAttributionText(String attribution) {
+			Objects.requireNonNull(attributionText, "Attribution text can not be null");
+			this.attributionText.add(attribution);
 			return this;
 		}
 		

--- a/src/test/java/org/spdx/library/model/SpdxFileTest.java
+++ b/src/test/java/org/spdx/library/model/SpdxFileTest.java
@@ -447,17 +447,19 @@ public class SpdxFileTest extends TestCase {
 	public void testSetAttributionText() throws InvalidSPDXAnalysisException {
 		String ATT1 = "attribution 1";
 		String ATT2 = "attribution 2";
-		String ATT3 = "attribution 3";
 		SpdxFile file = gmo.createSpdxFile(gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri()),
 				"filename", COMPLEX_LICENSE, Arrays.asList(CONJUNCTIVE_LICENSES), SpdxConstants.NOASSERTION_VALUE, SHA1)
-				.setAttributionText(ATT1)
+				.addAttributionText(ATT1)
 				.build();
-		assertEquals(file.getAttributionText().get(), ATT1);
-		file.setAttributionText(ATT2);
+		assertEquals(1, file.getAttributionText().size());
+		assertTrue(file.getAttributionText().contains(ATT1));
+		file.getAttributionText().add(ATT2);
 		SpdxFile file2 = new SpdxFile(file.getModelStore(), file.getDocumentUri(), file.getId(), file.getCopyManager(), false);
-		assertEquals(file2.getAttributionText().get(), ATT2);
-		file2.setAttributionText(ATT3);
-		assertEquals(file2.getAttributionText().get(), ATT3);
+		assertEquals(2, file2.getAttributionText().size());
+		assertTrue(file2.getAttributionText().contains(ATT1));
+		assertTrue(file2.getAttributionText().contains(ATT2));
+		file2.getAttributionText().clear();
+		assertEquals(0, file2.getAttributionText().size());
 	}
 	
 	@SuppressWarnings("deprecation")

--- a/src/test/java/org/spdx/library/model/SpdxPackageTest.java
+++ b/src/test/java/org/spdx/library/model/SpdxPackageTest.java
@@ -1400,15 +1400,18 @@ public class SpdxPackageTest extends TestCase {
 				.setVersionInfo(VERSION1)
 				.setSourceInfo(SOURCEINFO1)
 				.setExternalRefs(externalRefs)
-				.setAttributionText(ATT1)
+				.addAttributionText(ATT1)
 				.build();
 		
-		assertEquals(ATT1, pkg.getAttributionText().get());
+		assertEquals(1, pkg.getAttributionText().size());
+		assertTrue(pkg.getAttributionText().contains(ATT1));
+		pkg.getAttributionText().add(ATT2);
 		SpdxPackage pkg2 = new SpdxPackage(pkg.getModelStore(), pkg.getDocumentUri(), pkg.getId(), pkg.getCopyManager(), false);
-		assertEquals(ATT1, pkg2.getAttributionText().get());
-		pkg2.setAttributionText(ATT2);
-		assertEquals(ATT2, pkg2.getAttributionText().get());
-		assertEquals(ATT2, pkg.getAttributionText().get());
+		assertEquals(2, pkg2.getAttributionText().size());
+		assertTrue(pkg2.getAttributionText().contains(ATT1));
+		assertTrue(pkg2.getAttributionText().contains(ATT2));
+		pkg2.getAttributionText().clear();
+		assertEquals(0, pkg2.getAttributionText().size());
 	}
 
 	/**


### PR DESCRIPTION
To match the cardinality of the SPDX 2.2 spec

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>