### PR TITLE
Revert "Relax sha1 requirement for packages, files, and external ref.  "

### DIFF
--- a/src/main/java/org/spdx/library/model/ExternalDocumentRef.java
+++ b/src/main/java/org/spdx/library/model/ExternalDocumentRef.java
@@ -171,6 +171,9 @@ public class ExternalDocumentRef extends ModelObject implements Comparable<Exter
 			if (verify.size() > 0) {
 				throw new InvalidSPDXAnalysisException("Invalid checksum: "+verify.get(0));
 			}
+			if (!ChecksumAlgorithm.SHA1.equals(checksum.getAlgorithm())) {
+				throw new InvalidSPDXAnalysisException("Checksum algorithm must be of type SHA1");
+			}
 		}
 		setPropertyValue(SpdxConstants.PROP_EXTERNAL_DOC_CHECKSUM, checksum);
 		return this;
@@ -290,6 +293,9 @@ public class ExternalDocumentRef extends ModelObject implements Comparable<Exter
 				retval.add("Missing checksum for external document "+uri);
 			} else {
 				retval.addAll(checksum.get().verify(verifiedIds));
+				if (checksum.get().getAlgorithm() != ChecksumAlgorithm.SHA1) {
+					retval.add("Checksum algorithm is not SHA1 for external reference "+uri);
+				}
 			}
 		} catch (InvalidSPDXAnalysisException e) {
 			logger.error("error getting checksum",e);

--- a/src/main/java/org/spdx/library/model/SpdxFile.java
+++ b/src/main/java/org/spdx/library/model/SpdxFile.java
@@ -286,6 +286,20 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 		for (Checksum checksum:checksums) {
 			retval.addAll(addNameToWarnings(checksum.verify(verifiedIds)));
 		}
+		String sha1;
+		try {
+			sha1 = getSha1();
+			if (sha1 == null || sha1.isEmpty()) {
+				retval.add("Missing required SHA1 hashcode value for "+fileName);
+			} else {
+				String warning = SpdxVerificationHelper.verifyChecksumString(sha1, ChecksumAlgorithm.SHA1);
+				if (warning != null) {
+					retval.add(warning + " for file "+fileName);
+				}
+			}
+		} catch (InvalidSPDXAnalysisException e) {
+			retval.add("Error getting sha1");
+		}
 		return retval;
 	}
 


### PR DESCRIPTION
Reverts spdx/Spdx-Java-Library#13

Per SPDX spec issue spdx/spdx-spec#282 the decision was made to keep the mandatory sha256 checksum.