### PR TITLE
Remove the requirement for a SHA1 checksum in the SPDX Package

### DIFF
--- a/src/main/java/org/spdx/library/model/ModelObject.java
+++ b/src/main/java/org/spdx/library/model/ModelObject.java
@@ -1091,15 +1091,14 @@ public abstract class ModelObject {
 	 */
 	public SpdxPackage.SpdxPackageBuilder createPackage(String id, String name,
 				AnyLicenseInfo concludedLicense, 
-				String copyrightText, Checksum sha1, AnyLicenseInfo licenseDeclared) {
+				String copyrightText, AnyLicenseInfo licenseDeclared) {
 		Objects.requireNonNull(id, "ID can not be null");
 		Objects.requireNonNull(name, "Name can not be null");
-		Objects.requireNonNull(sha1, "Sha1 can not be null");
 		Objects.requireNonNull(concludedLicense, "Concluded license can not be null");
 		Objects.requireNonNull(licenseDeclared, "License declared can not be null");
 		Objects.requireNonNull(copyrightText, "copyright text can not be null");
 		return new SpdxPackage.SpdxPackageBuilder(modelStore, documentUri, id, copyManager,
-				name, concludedLicense, copyrightText, sha1, licenseDeclared);
+				name, concludedLicense, copyrightText, licenseDeclared);
 	}
 
 	/**

--- a/src/main/java/org/spdx/library/model/SpdxPackage.java
+++ b/src/main/java/org/spdx/library/model/SpdxPackage.java
@@ -84,10 +84,6 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		setCopyrightText(spdxPackageBuilder.copyrightText);
 		setName(spdxPackageBuilder.name);
 		setLicenseConcluded(spdxPackageBuilder.concludedLicense);
-		if (!spdxPackageBuilder.sha1.getAlgorithm().equals(ChecksumAlgorithm.SHA1)) {
-			throw new InvalidSPDXAnalysisException("Invalid SHA1 checksum algorithm for SpdxPackage.  Must be SHA1");
-		}
-		addChecksum(spdxPackageBuilder.sha1);
 		setLicenseDeclared(spdxPackageBuilder.licenseDeclared);
 		
 		// optional parameters - SpdxElement
@@ -101,13 +97,7 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		getAttributionText().addAll(spdxPackageBuilder.attributionText);
 		
 		// optional parameters - SpdxPackage
-		Iterator<Checksum> iter = spdxPackageBuilder.checksums.iterator();
-		while (iter.hasNext()) {
-			Checksum cksum = iter.next();
-			if (!cksum.equals(spdxPackageBuilder.sha1)) {
-				getChecksums().add(cksum);
-			}
-		}
+		getChecksums().addAll(spdxPackageBuilder.checksums);
 
 		setDescription(spdxPackageBuilder.description);
 		setDownloadLocation(spdxPackageBuilder.downloadLocation);
@@ -695,7 +685,6 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		
 		// required fields - SpdxPackage
 		AnyLicenseInfo licenseDeclared;
-		Checksum sha1;
 		
 		// optional fields - SpdxElement
 		Collection<Annotation> annotations = new ArrayList<Annotation>();
@@ -732,12 +721,11 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		 * @param concludedLicense license concluded
 		 * @param licenseInfosFromFile collection of seen licenses
 		 * @param copyrightText Copyright text
-		 * @param sha1 - Sha1 checksum value
 		 * @param licenseDeclared - Declared license for the package
 		 */
 		public SpdxPackageBuilder(IModelStore modelStore, String documentUri, String id, 
 				@Nullable ModelCopyManager copyManager, String name,AnyLicenseInfo concludedLicense, 
-				String copyrightText, Checksum sha1, AnyLicenseInfo licenseDeclared) {
+				String copyrightText, AnyLicenseInfo licenseDeclared) {
 			Objects.requireNonNull(modelStore, "Model store can not be null");
 			Objects.requireNonNull(documentUri, "Document URI can not be null");
 			Objects.requireNonNull(id, "ID can not be null");
@@ -745,14 +733,12 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 			Objects.requireNonNull(concludedLicense, "Concluded license can not be null");
 			Objects.requireNonNull(copyrightText, "Copyright text can not be null");
 			Objects.requireNonNull(licenseDeclared, "License declared can not be null");
-			Objects.requireNonNull(sha1, "SHA1 can not be null");
 			this.modelStore = modelStore;
 			this.documentUri = documentUri;
 			this.id = id;
 			this.name = name;
 			this.concludedLicense = concludedLicense;
 			this.copyrightText = copyrightText;
-			this.sha1 = sha1;
 			this.licenseDeclared = licenseDeclared;
 			this.copyManager = copyManager;
 		}

--- a/src/main/java/org/spdx/storage/simple/InMemSpdxStore.java
+++ b/src/main/java/org/spdx/storage/simple/InMemSpdxStore.java
@@ -376,4 +376,12 @@ public class InMemSpdxStore implements IModelStore {
 		}
 	}
 
+	/**
+	 * Remove all existing elements, properties, and values for a document including the document itself
+	 * @param documentUri
+	 */
+	public void clear(String documentUri) {
+		Objects.requireNonNull(documentUri, "Document uri can not be null");
+		this.documentValues.put(documentUri, new ConcurrentHashMap<String, StoredTypedItem>());
+	}
 }

--- a/src/test/java/org/spdx/library/model/SpdxDocumentTest.java
+++ b/src/test/java/org/spdx/library/model/SpdxDocumentTest.java
@@ -154,7 +154,8 @@ public class SpdxDocumentTest extends TestCase {
 				.build();
 
 		PACKAGE1 = gmo.createPackage(gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri()),
-				"Package 1", LICENSE1, "Pkg Copyright1", CHECKSUM1, LICENSE2)
+				"Package 1", LICENSE1, "Pkg Copyright1", LICENSE2)
+				.addChecksum(CHECKSUM1)
 				.setLicenseInfosFromFile(Arrays.asList(new SimpleLicensingInfo[] {LICENSE2}))
 				.setComment("Package Comments1")
 				.setDescription("Pkg Description 1")
@@ -173,7 +174,8 @@ public class SpdxDocumentTest extends TestCase {
 				.build();
 
 		PACKAGE2 = gmo.createPackage(gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri()),
-				"Package 2", LICENSE2, "Pkg Copyright2", CHECKSUM2, LICENSE3)
+				"Package 2", LICENSE2, "Pkg Copyright2", LICENSE3)
+				.addChecksum(CHECKSUM2)
 				.setLicenseInfosFromFile(Arrays.asList(new SimpleLicensingInfo[] {LICENSE2}))
 				.setComment("Package Comments2")
 				.setDescription("Pkg Description 2")
@@ -192,7 +194,8 @@ public class SpdxDocumentTest extends TestCase {
 				.build();
 
 		PACKAGE3 = gmo.createPackage(gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri()),
-				"Package 3", LICENSE1, "Pkg Copyright3", CHECKSUM1, LICENSE3)
+				"Package 3", LICENSE1, "Pkg Copyright3", LICENSE3)
+				.addChecksum(CHECKSUM1)
 				.setLicenseInfosFromFile(Arrays.asList(new SimpleLicensingInfo[] {LICENSE2}))
 				.setComment("Package Comments3")
 				.setDescription("Pkg Description 3")

--- a/src/test/java/org/spdx/library/model/SpdxPackageTest.java
+++ b/src/test/java/org/spdx/library/model/SpdxPackageTest.java
@@ -187,13 +187,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testVerify() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -232,14 +232,14 @@ public class SpdxPackageTest extends TestCase {
 	public void testEquivalent() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id1 = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		String id2 = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id1, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id1, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -261,7 +261,7 @@ public class SpdxPackageTest extends TestCase {
 				.build();
 		
 		assertTrue(pkg.equivalent(pkg));
-		SpdxPackage pkg2 = gmo.createPackage(id2, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg2 = gmo.createPackage(id2, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -373,13 +373,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetFilesAnalyzed() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -414,13 +414,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetLicenseDeclared() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -462,8 +462,8 @@ public class SpdxPackageTest extends TestCase {
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
-//				.setChecksums(checksums)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
+				.addChecksum(CHECKSUM1)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
 				.setRelationships(relationships)
@@ -507,13 +507,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetDescription() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -549,13 +549,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetDownloadLocation() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -591,13 +591,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetHomepage() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -633,13 +633,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetOriginator() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -675,13 +675,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetPackageFileName() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -716,13 +716,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetPackageVerificationCode() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -757,13 +757,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetSourceInfo() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -798,13 +798,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetSummary() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -839,13 +839,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetSupplier() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -880,13 +880,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetVersionInfo() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -921,14 +921,14 @@ public class SpdxPackageTest extends TestCase {
 	public void testAddExternalRef() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs1 = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		List<ExternalRef> externalRefs2 = Arrays.asList(new ExternalRef[] {EXTERNAL_REF2, EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -963,13 +963,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testAddFile() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1003,13 +1003,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testCompareTo() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
 		SpdxPackage pkg = gmo.createPackage(gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri()),
-				PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+				PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1031,7 +1031,7 @@ public class SpdxPackageTest extends TestCase {
 				.build();
 		
 		SpdxPackage sameName = gmo.createPackage(gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri()),
-				PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+				PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1053,7 +1053,7 @@ public class SpdxPackageTest extends TestCase {
 				.build();
 		
 		SpdxPackage pkg3 = gmo.createPackage(gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri()),
-				PKG_NAME2, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+				PKG_NAME2, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1086,13 +1086,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testGetSha1() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1129,13 +1129,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetLicenseConcluded() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1169,13 +1169,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetCopyrightText() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1210,13 +1210,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetLicenseComments()  throws InvalidSPDXAnalysisException{
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1252,13 +1252,13 @@ public class SpdxPackageTest extends TestCase {
 		List<Annotation> annotations1 = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Annotation> annotations2 = Arrays.asList(new Annotation[] {ANNOTATION1, ANNOTATION2});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations1)
@@ -1294,13 +1294,13 @@ public class SpdxPackageTest extends TestCase {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships1 = Arrays.asList(new Relationship[] {RELATIONSHIP1});
 		List<Relationship> relationships2 = Arrays.asList(new Relationship[] {RELATIONSHIP1, RELATIONSHIP2});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1334,13 +1334,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetComment() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1372,7 +1372,7 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetAttributionText() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
@@ -1381,7 +1381,7 @@ public class SpdxPackageTest extends TestCase {
 		String ATT1 = "attribution 1";
 		String ATT2 = "attribution 2";
 
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)
@@ -1420,13 +1420,13 @@ public class SpdxPackageTest extends TestCase {
 	public void testSetNameString() throws InvalidSPDXAnalysisException {
 		List<Annotation> annotations = Arrays.asList(new Annotation[] {ANNOTATION1});
 		List<Relationship> relationships = Arrays.asList(new Relationship[] {RELATIONSHIP1});
-		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3});
+		List<Checksum> checksums = Arrays.asList(new Checksum[] {CHECKSUM2, CHECKSUM3, CHECKSUM1});
 		List<SpdxFile> files = Arrays.asList(new SpdxFile[] {FILE1, FILE2});
 		List<AnyLicenseInfo> licenseFromFiles = Arrays.asList(new AnyLicenseInfo[] {LICENSE2});
 		String id = gmo.getModelStore().getNextId(IdType.SpdxId, gmo.getDocumentUri());
 		List<ExternalRef> externalRefs = Arrays.asList(new ExternalRef[] {EXTERNAL_REF1});
 		
-		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, CHECKSUM1, LICENSE3)
+		SpdxPackage pkg = gmo.createPackage(id, PKG_NAME1, LICENSE1, COPYRIGHT_TEXT1, LICENSE3)
 				.setChecksums(checksums)
 				.setComment(PKG_COMMENT1)
 				.setAnnotations(annotations)

--- a/src/test/java/org/spdx/utility/compare/SpdxComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxComparerTest.java
@@ -404,7 +404,8 @@ public class SpdxComparerTest extends TestCase {
 				.setLicenseComments("LicenseComment2")
 				.setLineRange(LINE2_1, LINE2_2)
 				.build();
-		pkgA1 = gmo.createPackage("SPDXRef-pkgA1", NAMEA, LICENSE_CONCLUDEDA, COPYRIGHTA, CHECKSUM1, LICENSE_DECLAREDA)
+		pkgA1 = gmo.createPackage("SPDXRef-pkgA1", NAMEA, LICENSE_CONCLUDEDA, COPYRIGHTA, LICENSE_DECLAREDA)
+				.addChecksum(CHECKSUM1)
 				.setComment(COMMENTA)
 				.setAnnotations(ANNOTATIONSA)
 				.setRelationships(RELATIONSHIPSA)
@@ -423,7 +424,8 @@ public class SpdxComparerTest extends TestCase {
 				.setSupplier(SUPPLIERA)
 				.setVersionInfo(VERSIONINFOA)
 				.build();
-		pkgA2 = gmo.createPackage("SPDXRef-pkgA2", NAMEB, LICENSE_CONCLUDEDA, COPYRIGHTA, CHECKSUM1, LICENSE_DECLAREDA)
+		pkgA2 = gmo.createPackage("SPDXRef-pkgA2", NAMEB, LICENSE_CONCLUDEDA, COPYRIGHTA, LICENSE_DECLAREDA)
+				.addChecksum(CHECKSUM1)
 				.setComment(COMMENTA)
 				.setAnnotations(ANNOTATIONSA)
 				.setRelationships(RELATIONSHIPSA)
@@ -443,7 +445,8 @@ public class SpdxComparerTest extends TestCase {
 				.setVersionInfo(VERSIONINFOA)
 				.build();
 		
-		pkgA1_1 = gmo.createPackage("SPDXRef-pkgA11", NAMEA, LICENSE_CONCLUDEDA, COPYRIGHTA, CHECKSUM1, LICENSE_DECLAREDA)
+		pkgA1_1 = gmo.createPackage("SPDXRef-pkgA11", NAMEA, LICENSE_CONCLUDEDA, COPYRIGHTA, LICENSE_DECLAREDA)
+				.addChecksum(CHECKSUM1)
 				.setComment(COMMENTA)
 				.setAnnotations(ANNOTATIONSA)
 				.setRelationships(RELATIONSHIPSA)
@@ -463,7 +466,8 @@ public class SpdxComparerTest extends TestCase {
 				.setVersionInfo(VERSIONINFOA)
 				.build();
 		
-		pkgA1_2 = gmo.createPackage("SPDXRef-pkgA12", NAMEA, LICENSE_CONCLUDEDA, COPYRIGHTA, CHECKSUM1, LICENSE_DECLAREDA)
+		pkgA1_2 = gmo.createPackage("SPDXRef-pkgA12", NAMEA, LICENSE_CONCLUDEDA, COPYRIGHTA, LICENSE_DECLAREDA)
+				.addChecksum(CHECKSUM1)
 				.setComment(COMMENTA)
 				.setAnnotations(ANNOTATIONSA)
 				.setRelationships(RELATIONSHIPSA)
@@ -483,7 +487,8 @@ public class SpdxComparerTest extends TestCase {
 				.setVersionInfo(VERSIONINFOA)
 				.build();
 
-		pkgB1 = gmo.createPackage("SPDXRef-pkgB1", NAMEA, LICENSE_CONCLUDEDB, COPYRIGHTA, CHECKSUM1, LICENSE_DECLAREDB)
+		pkgB1 = gmo.createPackage("SPDXRef-pkgB1", NAMEA, LICENSE_CONCLUDEDB, COPYRIGHTA, LICENSE_DECLAREDB)
+				.addChecksum(CHECKSUM1)
 				.setComment(COMMENTA)
 				.setAnnotations(ANNOTATIONSA)
 				.setRelationships(RELATIONSHIPSA)
@@ -503,7 +508,8 @@ public class SpdxComparerTest extends TestCase {
 				.setVersionInfo(VERSIONINFOA)
 				.build();
 
-		pkgB2 = gmo.createPackage("SPDXRef-pkgB2", NAMEB, LICENSE_CONCLUDEDB, COPYRIGHTA, CHECKSUM1, LICENSE_DECLAREDB)
+		pkgB2 = gmo.createPackage("SPDXRef-pkgB2", NAMEB, LICENSE_CONCLUDEDB, COPYRIGHTA, LICENSE_DECLAREDB)
+				.addChecksum(CHECKSUM1)
 				.setComment(COMMENTB)
 				.setAnnotations(ANNOTATIONSA)
 				.setRelationships(RELATIONSHIPSA)

--- a/src/test/java/org/spdx/utility/compare/SpdxPackageComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxPackageComparerTest.java
@@ -408,7 +408,8 @@ public class SpdxPackageComparerTest extends TestCase {
 			String originator, String packageFilename, SpdxPackageVerificationCode verificationCode,
 			String sourceinfo, String summary, String supplier, String versioninfo, 
 			boolean filesAnalyzed, Collection<ExternalRef> externalRefs, Checksum sha1) throws InvalidSPDXAnalysisException {
-		return doc.createPackage("SPDXRef-"+name, name, licenseConcluded, copyright, sha1, licenseDeclared)
+		return doc.createPackage("SPDXRef-"+name, name, licenseConcluded, copyright,  licenseDeclared)
+				.addChecksum(sha1)
 				.setComment(comment)
 				.setAnnotations(annotations)
 				.setRelationships(relationships)


### PR DESCRIPTION
The spec no longer requires a SHA1 Checksum for packages.

WARING: This introduces an incompatibility in the SpdxPackageBuilder interface with previous versions.