### PR TITLE
Fix no assertion strings not being handled properly

### DIFF
--- a/src/main/java/org/spdx/library/model/ModelObject.java
+++ b/src/main/java/org/spdx/library/model/ModelObject.java
@@ -340,16 +340,26 @@ public abstract class ModelObject {
 	 */
 	protected Optional<String> getStringPropertyValue(String propertyName) throws InvalidSPDXAnalysisException {
 		Optional<Object> result = getObjectPropertyValue(propertyName);
-		Optional<String> retval;
 		if (result.isPresent()) {
-			if (!(result.get() instanceof String)) {
+			if (result.get() instanceof String) {
+				return Optional.of((String)result.get());
+			} else if (result.get() instanceof IndividualUriValue) {
+				String uri = ((IndividualUriValue)result.get()).getIndividualURI();
+				if (SpdxConstants.URI_VALUE_NONE.equals(uri)) {
+					return Optional.of(SpdxConstants.NONE_VALUE);
+				} else if (SpdxConstants.URI_VALUE_NOASSERTION.equals(uri)) {
+					return Optional.of(SpdxConstants.NOASSERTION_VALUE);
+				} else {
+					logger.error("Can not convert a URI value to String: "+uri);
+					throw new SpdxInvalidTypeException("Can not convert a URI value to String: "+uri);
+				}
+			} else {
+				logger.error("Property "+propertyName+" is not of type String");
 				throw new SpdxInvalidTypeException("Property "+propertyName+" is not of type String");
 			}
-			retval = Optional.of((String)result.get());
 		} else {
-			retval = Optional.empty();
+			return Optional.empty();
 		}
-		return retval;
 	}
 	
 	/**

--- a/src/main/java/org/spdx/library/model/SimpleUriValue.java
+++ b/src/main/java/org/spdx/library/model/SimpleUriValue.java
@@ -80,7 +80,8 @@ public class SimpleUriValue implements IndividualUriValue {
 		} else if (SpdxConstants.EXTERNAL_EXTRACTED_LICENSE_URI_PATTERN.matcher(uri).matches()) {
 			return ExternalExtractedLicenseInfo.uriToExternalExtractedLicense(uri, store, documentUri, copyManager);
 		} else if (SpdxConstants.URI_VALUE_NONE.equals(uri)) {
-			// Assume this is a None license since other NONE would be strings
+			// Default value is a license, although it can also be a string or an SpdxElement
+			// the caller should override the type based on the type expected
 			return new SpdxNoneLicense(store, documentUri);
 		} else if (SpdxConstants.URI_VALUE_NOASSERTION.equals(uri)) {
 			return new SpdxNoAssertionLicense(store, documentUri);


### PR DESCRIPTION
NoAssertion is not converted to strings in all cases.  This PR updates the getStringValue method to convert any NONE or NOASSERTION values to strings.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>