### PR TITLE
Fix verify to check IDs and verify document described elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.spdx</groupId>
     <artifactId>java-spdx-library</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>java-spdx-library</name>

--- a/src/main/java/org/spdx/library/SpdxVerificationHelper.java
+++ b/src/main/java/org/spdx/library/SpdxVerificationHelper.java
@@ -254,4 +254,12 @@ public class SpdxVerificationHelper {
 					SpdxConstants.DOWNLOAD_LOCATION_PATTERN.pattern();
 		}
 	}
+	
+	/**
+	 * @param id
+	 * @return true if the ID is a valid SPDX ID reference
+	 */
+	public static boolean verifySpdxId(String id) {
+		return SpdxConstants.SPDX_ELEMENT_REF_PATTERN.matcher(id).matches();
+	}
 }

--- a/src/main/java/org/spdx/library/model/ModelObject.java
+++ b/src/main/java/org/spdx/library/model/ModelObject.java
@@ -159,21 +159,21 @@ public abstract class ModelObject {
 	
 	/**
 	 * Implementation of the specific verifications for this model object
-	 * @param verifiedIds list of all Id's which have already been verifieds - prevents infinite recursion
+	 * @param verifiedElementIds list of all Element Id's which have already been verified - prevents infinite recursion
 	 * @return Any verification errors or warnings associated with this object
 	 */
-	protected abstract List<String> _verify(List<String> verifiedIds);
+	protected abstract List<String> _verify(List<String> verifiedElementIds);
 	
 	/**
-	 * @param verifiedIds list of all Id's which have already been verifieds - prevents infinite recursion
+	 * @param verifiedIElementds list of all element Id's which have already been verified - prevents infinite recursion
 	 * @return Any verification errors or warnings associated with this object
 	 */
-	public List<String> verify(List<String> verifiedIds) {
-		if (verifiedIds.contains(this.id)) {
+	public List<String> verify(List<String> verifiedIElementds) {
+		if (verifiedIElementds.contains(this.id)) {
 			return new ArrayList<>();
 		} else {
-			verifiedIds.add(id);
-			return _verify(verifiedIds);
+			// The verifiedElementId is added in the SpdxElement._verify method
+			return _verify(verifiedIElementds);
 		}
 	}
 	
@@ -964,7 +964,7 @@ public abstract class ModelObject {
 	protected List<String> verifyCollection(Collection<? extends ModelObject> collection, String warningPrefix, List<String> verifiedIds) {
 		List<String> retval = new ArrayList<>();
 		for (ModelObject mo:collection) {
-			for (String warning:mo.verify()) {
+			for (String warning:mo.verify(verifiedIds)) {
 				if (Objects.nonNull(warningPrefix)) {
 					retval.add(warningPrefix + warning);
 				} else {

--- a/src/main/java/org/spdx/library/model/SpdxDocument.java
+++ b/src/main/java/org/spdx/library/model/SpdxDocument.java
@@ -312,6 +312,10 @@ public class SpdxDocument extends SpdxElement {
 				retval.add("Document must have at least one relationship of type DOCUMENT_DESCRIBES");
 				// Note - relationships are verified in the superclass.  This should also recursively
 				// verify any other important objects.
+			} else {
+				for (SpdxElement element:getDocumentDescribes()) {
+					retval.addAll(element.verify(verifiedIds));
+				}
 			}
 		} catch (InvalidSPDXAnalysisException e) {
 			retval.add("Error getting document describes: "+e.getMessage());

--- a/src/main/java/org/spdx/library/model/SpdxElement.java
+++ b/src/main/java/org/spdx/library/model/SpdxElement.java
@@ -29,6 +29,7 @@ import org.spdx.library.DefaultModelStore;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.ModelCopyManager;
 import org.spdx.library.SpdxConstants;
+import org.spdx.library.SpdxVerificationHelper;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
 
@@ -86,6 +87,15 @@ public abstract class SpdxElement extends ModelObject {
 			return retval;
 		}
 		verifiedElementIds.add(this.getId());
+		// verify ID format
+		IdType idType = this.getModelStore().getIdType(this.getId());
+		if (IdType.SpdxId.equals(idType)) {
+			if (!SpdxVerificationHelper.verifySpdxId(this.getId())) {
+				retval.add("Invalid SPDX ID: "+this.getId()+".  Must match the pattern "+SpdxConstants.SPDX_ELEMENT_REF_PATTERN);
+			}
+		} else if (!IdType.SpdxId.equals(idType)) {
+			retval.add("Invalid ID for SPDX Element: "+this.getId()+".  Must be either a valid SPDX ID or Anonomous.");
+		}
 		try {
 			retval.addAll(verifyCollection(getAnnotations(), "Annotation Error: ", verifiedElementIds));
 		} catch (InvalidSPDXAnalysisException e1) {

--- a/src/main/java/org/spdx/library/model/SpdxElement.java
+++ b/src/main/java/org/spdx/library/model/SpdxElement.java
@@ -93,7 +93,7 @@ public abstract class SpdxElement extends ModelObject {
 			if (!SpdxVerificationHelper.verifySpdxId(this.getId())) {
 				retval.add("Invalid SPDX ID: "+this.getId()+".  Must match the pattern "+SpdxConstants.SPDX_ELEMENT_REF_PATTERN);
 			}
-		} else if (!IdType.SpdxId.equals(idType)) {
+		} else if (!IdType.Anonymous.equals(idType)) {
 			retval.add("Invalid ID for SPDX Element: "+this.getId()+".  Must be either a valid SPDX ID or Anonomous.");
 		}
 		try {

--- a/src/test/java/org/spdx/library/model/SpdxElementTest.java
+++ b/src/test/java/org/spdx/library/model/SpdxElementTest.java
@@ -83,7 +83,7 @@ public class SpdxElementTest extends TestCase {
 	 * @throws InvalidSPDXAnalysisException 
 	 */
 	public void testVerify() throws InvalidSPDXAnalysisException {
-		String id = "elementId";
+		String id = "SpdxRef-elementId";
 		SpdxElement element1 = new GenericSpdxElement(gmo.getModelStore(), gmo.getDocumentUri(), id, gmo.getCopyManager(), true);
 		assertEquals(0, element1.verify().size());
 		element1.setName(ELEMENT_NAME1);


### PR DESCRIPTION
This is related to https://github.com/spdx/spdx-java-jackson-store/issues/7

In addition to deeper checking, verify IDs, this PR also resolves a possible infinite recursion and improves the performance of Verify by only checking SPDX Element ID's for duplicate verifies.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>