### PR TITLE
Compare listed licenses by IDs only

### DIFF
--- a/src/main/java/org/spdx/library/model/ModelObject.java
+++ b/src/main/java/org/spdx/library/model/ModelObject.java
@@ -42,6 +42,7 @@ import org.spdx.library.model.license.ConjunctiveLicenseSet;
 import org.spdx.library.model.license.CrossRef.CrossRefBuilder;
 import org.spdx.library.model.license.DisjunctiveLicenseSet;
 import org.spdx.library.model.license.ListedLicenses;
+import org.spdx.library.model.license.SpdxListedLicense;
 import org.spdx.library.model.license.SpdxNoAssertionLicense;
 import org.spdx.library.model.license.SpdxNoneLicense;
 import org.spdx.library.model.pointer.ByteOffsetPointer;
@@ -701,6 +702,9 @@ public abstract class ModelObject {
 	public boolean equivalent(ModelObject compare, boolean ignoreRelatedElements) throws InvalidSPDXAnalysisException {
 		if (!this.getClass().equals(compare.getClass())) {
 			return false;
+		}
+		if (this.getClass().equals(SpdxListedLicense.class)) {
+		    return this.getId().equals(compare.getId());  // Listed licenses always equal if their ID's equal
 		}
 		List<String> propertyValueNames = getPropertyValueNames();
 		List<String> comparePropertyValueNames = new ArrayList<String>(compare.getPropertyValueNames());	// create a copy since we're going to modify it

--- a/src/main/java/org/spdx/library/model/ModelObject.java
+++ b/src/main/java/org/spdx/library/model/ModelObject.java
@@ -703,9 +703,6 @@ public abstract class ModelObject {
 		if (!this.getClass().equals(compare.getClass())) {
 			return false;
 		}
-		if (this.getClass().equals(SpdxListedLicense.class)) {
-		    return this.getId().equals(compare.getId());  // Listed licenses always equal if their ID's equal
-		}
 		List<String> propertyValueNames = getPropertyValueNames();
 		List<String> comparePropertyValueNames = new ArrayList<String>(compare.getPropertyValueNames());	// create a copy since we're going to modify it
 		for (String propertyName:propertyValueNames) {

--- a/src/main/java/org/spdx/library/model/ModelObject.java
+++ b/src/main/java/org/spdx/library/model/ModelObject.java
@@ -42,7 +42,6 @@ import org.spdx.library.model.license.ConjunctiveLicenseSet;
 import org.spdx.library.model.license.CrossRef.CrossRefBuilder;
 import org.spdx.library.model.license.DisjunctiveLicenseSet;
 import org.spdx.library.model.license.ListedLicenses;
-import org.spdx.library.model.license.SpdxListedLicense;
 import org.spdx.library.model.license.SpdxNoAssertionLicense;
 import org.spdx.library.model.license.SpdxNoneLicense;
 import org.spdx.library.model.pointer.ByteOffsetPointer;

--- a/src/main/java/org/spdx/library/model/license/License.java
+++ b/src/main/java/org/spdx/library/model/license/License.java
@@ -318,11 +318,11 @@ public abstract class License extends SimpleLicensingInfo {
 	}
 	
 	@Override
-	public boolean equivalent(ModelObject compare) throws InvalidSPDXAnalysisException {
+	public boolean equivalent(ModelObject compare, boolean ignoreExternalReferences) throws InvalidSPDXAnalysisException {
 		if (compare instanceof License) {
 			return LicenseCompareHelper.isLicenseTextEquivalent(this.getLicenseText(), ((License)compare).getLicenseText());
 		} else {
-			return super.equivalent(compare);
+			return super.equivalent(compare, ignoreExternalReferences);
 		}
 	}
 }

--- a/src/main/java/org/spdx/library/model/license/ListedLicenseException.java
+++ b/src/main/java/org/spdx/library/model/license/ListedLicenseException.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.ModelCopyManager;
 import org.spdx.library.SpdxConstants;
+import org.spdx.library.model.ModelObject;
 import org.spdx.licenseTemplate.LicenseTemplateRuleException;
 import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
 import org.spdx.storage.IModelStore;
@@ -119,5 +120,14 @@ public class ListedLicenseException extends LicenseException {
 			}
 		}
 	}
+	
+	   @Override
+	    public boolean equivalent(ModelObject compare, boolean ignoreRelatedElements) throws InvalidSPDXAnalysisException {
+	        if (compare instanceof ListedLicenseException) {
+	            return this.getId().equals(((ListedLicenseException)compare).getId()); // for listed license, the license ID is the only thing that matters
+	        } else {
+	            return super.equivalent(compare, ignoreRelatedElements);
+	        }
+	    }
 
 }

--- a/src/main/java/org/spdx/library/model/license/SpdxListedLicense.java
+++ b/src/main/java/org/spdx/library/model/license/SpdxListedLicense.java
@@ -212,11 +212,11 @@ public class SpdxListedLicense extends License {
 	}
 	
 	@Override
-	public boolean equivalent(ModelObject compare) throws InvalidSPDXAnalysisException {
+	public boolean equivalent(ModelObject compare, boolean ignoreRelatedElements) throws InvalidSPDXAnalysisException {
 		if (compare instanceof SpdxListedLicense) {
 			return this.getLicenseId().equals(((SpdxListedLicense)compare).getLicenseId());	// for listed license, the license ID is the only thing that matters
 		} else {
-			return super.equivalent(compare);
+			return super.equivalent(compare, ignoreRelatedElements);
 		}
 	}
 	

--- a/src/test/java/org/spdx/library/model/license/LicenseExpressionParserTest.java
+++ b/src/test/java/org/spdx/library/model/license/LicenseExpressionParserTest.java
@@ -207,4 +207,9 @@ public class LicenseExpressionParserTest extends TestCase {
 		assertTrue(result instanceof ExternalExtractedLicenseInfo);
 		assertEquals(externalExtractedId, ((ExternalExtractedLicenseInfo)result).getId());
 	}
+
+    public void regressionMitWith() throws InvalidSPDXAnalysisException, InvalidLicenseStringException {
+        AnyLicenseInfo result = LicenseInfoFactory.parseSPDXLicenseString("MIT WITH Autoconf-exception-2.0");
+        assertEquals("MIT WITH Autoconf-exception-2.0",result.toString());
+    }
 }


### PR DESCRIPTION
When checking for ModelObjects being equivalent, Listed Licenses should always be equivalent if the license ID's match.  There are several fields in a listed license which can change (e.g. templateText) and the license would still be considered equivalent.
 
Resolves https://github.com/spdx/tools-java/issues/14
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>