### PR TITLE
Fix javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-javadoc-plugin</artifactId>
-			<version>2.9</version>
+			<version>3.2.0</version>
 			<configuration>
 				<quiet>true</quiet>
 				<source>8</source>

--- a/src/main/java/org/spdx/library/Read.java
+++ b/src/main/java/org/spdx/library/Read.java
@@ -94,11 +94,15 @@ public class Read {
 	}
 	
 	/**
-	 * Serializes an SPDX document stored in the modelStore.  The specific format of the serialization will
-	 * depend on the modelStore.
-	 * @param modelStore Storage for the model objects
-	 * @param documentUri SPDX Document URI for a document associated with this model
-	 * @param stream Output stream for serialization
+	 * Serializes an SPDX document stored in the modelStore. The specific format of
+	 * the serialization will depend on the modelStore.
+	 * 
+	 * @param modelStore  Storage for the model objects
+	 * @param documentUri SPDX Document URI for a document associated with this
+	 *                    model
+	 * @param stream      Output stream for serialization
+	 * @throws InvalidSPDXAnalysisException
+	 * @throws IOException
 	 */
 	public static void serialize(ISerializableModelStore modelStore, String documentUri, OutputStream stream) throws InvalidSPDXAnalysisException, IOException {
 		IModelStoreLock lock = modelStore.enterCriticalSection(documentUri, true);
@@ -128,10 +132,13 @@ public class Read {
 	}
 	
 	/**
-	 * @param modelStore Storage for the model objects
-	 * @param documentUri SPDX Document URI for a document associated with this model
-	 * @param typeFilter Optional parameter to specify the type of objects to be retrieved
+	 * @param modelStore  Storage for the model objects
+	 * @param documentUri SPDX Document URI for a document associated with this
+	 *                    model
+	 * @param typeFilter  Optional parameter to specify the type of objects to be
+	 *                    retrieved
 	 * @return Stream of all items store within the document
+	 * @throws InvalidSPDXAnalysisException
 	 */
 	public static Stream<? extends ModelObject> getAllItems(IModelStore modelStore, String documentUri, 
 			String typeFilter) throws InvalidSPDXAnalysisException { 

--- a/src/main/java/org/spdx/library/model/ModelObject.java
+++ b/src/main/java/org/spdx/library/model/ModelObject.java
@@ -83,7 +83,7 @@ import org.spdx.storage.IModelStore.ModelUpdate;
  *   - String - Java Strings
  *   - Booolean - Java Boolean or primitive boolean types
  *   - ModelObject - A concrete subclass of this type
- *   - Collection<T> - A Collection of type T where T is one of the supported non-collection types
+ *   - {@literal Collection<T>} - A Collection of type T where T is one of the supported non-collection types
  *     
  * This class also handles the conversion of a ModelObject to and from a TypeValue for storage in the ModelStore.
  *
@@ -554,15 +554,17 @@ public abstract class ModelObject {
 	}
 	
 	/**
-	 * Add a value to a collection of values associated with a property.  If a value is a ModelObject and does not
-	 * belong to the document, it will be copied into the object store
-	 * @param stModelStore Model store for the properties
+	 * Add a value to a collection of values associated with a property. If a value
+	 * is a ModelObject and does not belong to the document, it will be copied into
+	 * the object store
+	 * 
+	 * @param stModelStore  Model store for the properties
 	 * @param stDocumentUri Unique document URI
-	 * @param stId ID of the item to associate the property with
+	 * @param stId          ID of the item to associate the property with
 	 * @param propertyName  Name of the property
-	 * @param value to add
-	 * @param copyOnReference if non null, any ModelObject property value not stored in the stModelStore under the stDocumentUri will be copied to make it available
-	 * @throws InvalidSPDXAnalysisException 
+	 * @param value         to add
+	 * @param copyManager
+	 * @throws InvalidSPDXAnalysisException
 	 */
 	protected static void addValueToCollection(IModelStore stModelStore, String stDocumentUri, String stId, 
 			String propertyName, Object value, ModelCopyManager copyManager) throws InvalidSPDXAnalysisException {
@@ -958,7 +960,7 @@ public abstract class ModelObject {
 	/**
 	 * Verifies all elements in a collection
 	 * @param collection collection to be verifies
-	 * @verifiedIds verifiedIds list of all Id's which have already been verifieds - prevents infinite recursion
+	 * @param verifiedIds verifiedIds list of all Id's which have already been verifieds - prevents infinite recursion
 	 * @param warningPrefix String to prefix any warning messages
 	 */
 	protected List<String> verifyCollection(Collection<? extends ModelObject> collection, String warningPrefix, List<String> verifiedIds) {
@@ -1001,9 +1003,10 @@ public abstract class ModelObject {
 	}
 	
 	/**
-	 * @param relatedSpdxElement The SPDX Element that is related
-	 * @param relationshipType Type of relationship - See the specification for a description of the types
-	 * @param comment optional comment for the relationship
+	 * @param relatedElement   The SPDX Element that is related
+	 * @param relationshipType Type of relationship - See the specification for a
+	 *                         description of the types
+	 * @param comment          optional comment for the relationship
 	 * @return
 	 * @throws InvalidSPDXAnalysisException
 	 */
@@ -1159,9 +1162,7 @@ public abstract class ModelObject {
 	 * @param id - ID - must be an SPDX ID type
 	 * @param name - File name
 	 * @param concludedLicense license concluded
-	 * @param seenLicense collection of seen licenses
 	 * @param copyrightText Copyright text
-	 * @param sha1 Sha1 checksum
 	 * @param licenseDeclared Declared license for the package
 	 * @return SpdxPackageBuilder with all required fields for a filesAnalyzed=false
 	 */

--- a/src/main/java/org/spdx/library/model/ModelStorageClassConverter.java
+++ b/src/main/java/org/spdx/library/model/ModelStorageClassConverter.java
@@ -50,12 +50,16 @@ public class ModelStorageClassConverter {
 	static ModelCopyManager tempMgr = new ModelCopyManager();//TODO: This is temporary - move to a parameter to ModelObject - this is not currently threadsafe
 
 	/**
-	 * Converts any typed value or individual value objects to a ModelObject, returning an existing ModelObject if it exists or creates a new ModelObject
-	 * @param value Value which may be a TypedValue
-	 * @param documenentUri Document URI to use when converting a typedValue
-	 * @param modelStore ModelStore to use in fetching or creating
-	 * @param copyManager if not null, copy any referenced ID's outside of this document/model store
-	 * @return the object itself unless it is a TypedValue, in which case a ModelObject is returned
+	 * Converts any typed value or individual value objects to a ModelObject,
+	 * returning an existing ModelObject if it exists or creates a new ModelObject
+	 * 
+	 * @param value       Value which may be a TypedValue
+	 * @param documentUri Document URI to use when converting a typedValue
+	 * @param modelStore  ModelStore to use in fetching or creating
+	 * @param copyManager if not null, copy any referenced ID's outside of this
+	 *                    document/model store
+	 * @return the object itself unless it is a TypedValue, in which case a
+	 *         ModelObject is returned
 	 * @throws InvalidSPDXAnalysisException
 	 */
 	public static Object storedObjectToModelObject(Object value, String documentUri, IModelStore modelStore,
@@ -72,12 +76,16 @@ public class ModelStorageClassConverter {
 	};
 	
 	/**
-	 * Converts any typed value or IndividualValue objects to a ModelObject, returning an existing ModelObject if it exists or creates a new ModelObject
-	 * @param value Value which may be a TypedValue
-	 * @param documenentUri Document URI to use when converting a typedValue
-	 * @param stModelStore ModelStore to use in fetching or creating
-	 * @param copyManager if not null, copy any referenced ID's outside of this document/model store
-	 * @return the object itself unless it is a TypedValue, in which case a ModelObject is returned
+	 * Converts any typed value or IndividualValue objects to a ModelObject,
+	 * returning an existing ModelObject if it exists or creates a new ModelObject
+	 * 
+	 * @param value         Value which may be a TypedValue
+	 * @param stDocumentUri Document URI to use when converting a typedValue
+	 * @param stModelStore  ModelStore to use in fetching or creating
+	 * @param copyManager   if not null, copy any referenced ID's outside of this
+	 *                      document/model store
+	 * @return the object itself unless it is a TypedValue, in which case a
+	 *         ModelObject is returned
 	 * @throws InvalidSPDXAnalysisException
 	 */
 	public static Optional<Object> optionalStoredObjectToModelObject(Optional<Object> value, 

--- a/src/main/java/org/spdx/library/model/RelatedElementCollection.java
+++ b/src/main/java/org/spdx/library/model/RelatedElementCollection.java
@@ -53,11 +53,10 @@ public class RelatedElementCollection implements Collection<SpdxElement> {
 	private SpdxElement owningElement;
 
 	/**
-	 * @param modelStore model store storing the information
-	 * @param documentUri document URI for the elements
-	 * @param id ID of the SpdxElement containing the relationship
-	 * @param relationshipTypeFilter relationship type to filter the results collection on - if null, do not filter
-	 * @throws InvalidSPDXAnalysisException 
+	 * @param owningElement
+	 * @param relationshipTypeFilter relationship type to filter the results
+	 *                               collection on - if null, do not filter
+	 * @throws InvalidSPDXAnalysisException
 	 */
 	public RelatedElementCollection(SpdxElement owningElement,
 			@Nullable RelationshipType relationshipTypeFilter) throws InvalidSPDXAnalysisException {

--- a/src/main/java/org/spdx/library/model/SpdxPackage.java
+++ b/src/main/java/org/spdx/library/model/SpdxPackage.java
@@ -721,15 +721,19 @@ public class SpdxPackage extends SpdxItem implements Comparable<SpdxPackage> {
 		boolean filesAnalyzed = true;
 				
 		/**
-		 * Build an SpdxPackage with the required parameters if isFilesAnalyzed is false - note isFilesAnalyzed must be explicitly set to false
-		 * @param modelStore Storage for the model objects
-		 * @param documentUri SPDX Document URI for a document associated with this model
-		 * @param id ID for this object - must be unique within the SPDX document
-		 * @param name - File name
-		 * @param concludedLicense license concluded
-		 * @param licenseInfosFromFile collection of seen licenses
-		 * @param copyrightText Copyright text
-		 * @param licenseDeclared - Declared license for the package
+		 * Build an SpdxPackage with the required parameters if isFilesAnalyzed is false
+		 * - note isFilesAnalyzed must be explicitly set to false
+		 * 
+		 * @param modelStore       Storage for the model objects
+		 * @param documentUri      SPDX Document URI for a document associated with this
+		 *                         model
+		 * @param id               ID for this object - must be unique within the SPDX
+		 *                         document
+		 * @param name             File name
+		 * @param copyManager
+		 * @param concludedLicense
+		 * @param copyrightText    Copyright text
+		 * @param licenseDeclared  Declared license for the package
 		 */
 		public SpdxPackageBuilder(IModelStore modelStore, String documentUri, String id, 
 				@Nullable ModelCopyManager copyManager, String name,AnyLicenseInfo concludedLicense, 

--- a/src/main/java/org/spdx/library/model/SpdxSnippet.java
+++ b/src/main/java/org/spdx/library/model/SpdxSnippet.java
@@ -242,13 +242,9 @@ public class SpdxSnippet extends SpdxItem implements Comparable<SpdxSnippet> {
 	}
 	
 	/**
-	 * @param lineRange the lineRange to set
+	 * @param startLine the start position of lineRange to set, inclusive
+	 * @param endLine   the end position of lineRange to set, exclusive
 	 * @return this to chain setters
-	 * @throws InvalidSPDXAnalysisException 
-	 */
-	/**
-	 * @param lineRange
-	 * @return
 	 * @throws InvalidSPDXAnalysisException
 	 */
 	public SpdxSnippet setLineRange(int startLine, int endLine) throws InvalidSPDXAnalysisException {

--- a/src/main/java/org/spdx/library/model/license/ExternalExtractedLicenseInfo.java
+++ b/src/main/java/org/spdx/library/model/license/ExternalExtractedLicenseInfo.java
@@ -157,11 +157,14 @@ public class ExternalExtractedLicenseInfo extends ExtractedLicenseInfo implement
 	}
 	
 	/**
-	 * @param uri URI of the form externaldocumentnamespace#LicenseRef-XXXXX
+	 * @param externalLicenseUri URI of the form
+	 *                           externaldocumentnamespace#LicenseRef-XXXXX
 	 * @param stModelStore
 	 * @param stDocumentUri
-	 * @return ExternalSpdxRef an ExternalLicenseRef based on a URI of the form externaldocumentnamespace#LicenseRef-XXXXX
-	 * @param copyManager if non-null, create the external doc ref if it is not already in the ModelStore
+	 * @return ExternalSpdxRef an ExternalLicenseRef based on a URI of the form
+	 *         externaldocumentnamespace#LicenseRef-XXXXX
+	 * @param copyManager if non-null, create the external doc ref if it is not
+	 *                    already in the ModelStore
 	 * @throws InvalidSPDXAnalysisException
 	 */
 	public static ExternalExtractedLicenseInfo uriToExternalExtractedLicense(String externalLicenseUri, IModelStore stModelStore,

--- a/src/main/java/org/spdx/library/model/license/LicenseInfoFactory.java
+++ b/src/main/java/org/spdx/library/model/license/LicenseInfoFactory.java
@@ -116,7 +116,6 @@ public class LicenseInfoFactory {
 	/**
 	 * @param licenseID case insensitive
 	 * @return true if the licenseID belongs to an SPDX listed license
-	 * @throws InvalidSPDXAnalysisException 
 	 */
 	public static boolean isSpdxListedLicenseId(String licenseID)  {
 		return ListedLicenses.getListedLicenses().isSpdxListedLicenseId(licenseID);

--- a/src/main/java/org/spdx/library/model/license/ListedLicenses.java
+++ b/src/main/java/org/spdx/library/model/license/ListedLicenses.java
@@ -159,7 +159,6 @@ public class ListedLicenses {
 	/**
 	 * @param licenseId case insensitive
 	 * @return true if the licenseId belongs to an SPDX listed license
-	 * @throws InvalidSPDXAnalysisException 
 	 */
     public boolean isSpdxListedLicenseId(String licenseId) {
 		return this.licenseModelStore.isSpdxListedLicenseId(SpdxConstants.LISTED_LICENSE_URL, licenseId);
@@ -200,7 +199,7 @@ public class ListedLicenses {
     
 	/**
 	 * @return The version of the loaded license list in the form M.N, where M is the major release and N is the minor release.
-	 * If no license list is loaded, returns {@Link DEFAULT_LICENSE_LIST_VERSION}.
+	 * If no license list is loaded, returns {@link org.spdx.storage.listedlicense.SpdxListedLicenseModelStore#DEFAULT_LICENSE_LIST_VERSION}.
 	 */
 	public String getLicenseListVersion() {
 		return this.licenseModelStore.getLicenseListVersion();

--- a/src/main/java/org/spdx/licenseTemplate/HtmlTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/licenseTemplate/HtmlTemplateOutputHandler.java
@@ -167,7 +167,6 @@ public class HtmlTemplateOutputHandler implements ILicenseTemplateOutputHandler 
 	
 	/**
 	 * Format HTML for an optional string
-	 * @param text text for the optional license string
 	 * @param id ID used for the div 
 	 * @return
 	 */

--- a/src/main/java/org/spdx/licenseTemplate/SpdxLicenseTemplateHelper.java
+++ b/src/main/java/org/spdx/licenseTemplate/SpdxLicenseTemplateHelper.java
@@ -98,7 +98,6 @@ public class SpdxLicenseTemplateHelper {
 	 * @param licenseTemplate
 	 * @return
 	 * @throws LicenseTemplateRuleException 
-	 * @throws LicenseParserException 
 	 */
 	public static String templateTextToHtml(String licenseTemplate) throws LicenseTemplateRuleException {
 		HtmlTemplateOutputHandler htmlOutput = new HtmlTemplateOutputHandler();
@@ -114,8 +113,7 @@ public class SpdxLicenseTemplateHelper {
 	 * Converts template text to standard default text using any default parameters in the rules
 	 * @param template
 	 * @return
-	 * @throws LicenseTemplateRuleException 
-	 * @throws LicenseParserException 
+	 * @throws LicenseTemplateRuleException
 	 */
 	public static String templateToText(String template) throws LicenseTemplateRuleException {
 		TextTemplateOutputHandler textOutput = new TextTemplateOutputHandler();

--- a/src/main/java/org/spdx/licenseTemplate/SpdxLicenseTemplateHelper.java
+++ b/src/main/java/org/spdx/licenseTemplate/SpdxLicenseTemplateHelper.java
@@ -46,6 +46,7 @@ public class SpdxLicenseTemplateHelper {
 	 * @param licenseTemplate       License template to be parsed
 	 * @param templateOutputHandler Handles the text, optional text, and variable
 	 *                              rules text found
+	 * @throws LicenseTemplateRuleException
 	 * @throws LicenseParserException
 	 */
 	public static void parseTemplate(String licenseTemplate, ILicenseTemplateOutputHandler templateOutputHandler)
@@ -104,7 +105,6 @@ public class SpdxLicenseTemplateHelper {
 	 * @param licenseTemplate
 	 * @return
 	 * @throws LicenseTemplateRuleException
-	 * @throws LicenseParserException
 	 */
 	public static String templateTextToHtml(String licenseTemplate) throws LicenseTemplateRuleException {
 		HtmlTemplateOutputHandler htmlOutput = new HtmlTemplateOutputHandler();
@@ -123,7 +123,6 @@ public class SpdxLicenseTemplateHelper {
 	 * @param template
 	 * @return
 	 * @throws LicenseTemplateRuleException
-	 * @throws LicenseParserException
 	 */
 	public static String templateToText(String template) throws LicenseTemplateRuleException {
 		TextTemplateOutputHandler textOutput = new TextTemplateOutputHandler();

--- a/src/main/java/org/spdx/storage/IModelStore.java
+++ b/src/main/java/org/spdx/storage/IModelStore.java
@@ -132,7 +132,6 @@ public interface IModelStore extends AutoCloseable {
 	public List<String> getDocumentUris();
 
 	/**
-	 * @param modelStore Storage for the model objects
 	 * @param documentUri SPDX Document URI for a document associated with this model
 	 * @param typeFilter Optional parameter to specify the type of objects to be retrieved
 	 * @return Stream of all items store within the document

--- a/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
+++ b/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
@@ -44,7 +44,7 @@ public class StoredTypedItem extends TypedValue {
 	}
 	
 	/**
-	 * @returnProperty names for all properties having a value
+	 * @return Property names for all properties having a value
 	 */
 	public List<String> getPropertyValueNames() {
 		Iterator<Entry<String, Object>> iter = this.properties.entrySet().iterator();

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -332,11 +332,12 @@ public class LicenseCompareHelper {
 	}
 	
 	/**
-	 * Tokenizes the license text, normalizes quotes, lowercases and converts multi-words for better equiv. comparisons
-	 * @param tokenLocations location for all of the tokens
+	 * Tokenizes the license text, normalizes quotes, lowercases and converts
+	 * multi-words for better equiv. comparisons
+	 * 
+	 * @param tokenToLocation location for all of the tokens
 	 * @param licenseText
 	 * @return tokens
-	 * @throws IOException 
 	 */
 	public static String[] tokenizeLicenseText(String licenseText, Map<Integer, LineColumn> tokenToLocation) {
 		String textToTokenize = normalizeText(replaceMultWord(replaceSpace(licenseText))).toLowerCase();
@@ -633,7 +634,7 @@ public class LicenseCompareHelper {
 	
 	/**
 	 * Creates a regular expression pattern to match the start of a license text
-	 * @param nonOptionalText List of strings of non-optional text from the license template (see <code>List<String> getNonOptionalLicenseText</code>)
+	 * @param nonOptionalText List of strings of non-optional text from the license template (see {@literal List<String> getNonOptionalLicenseText})
 	 * @param numberOfWords Number of words to use in the match
 	 * @return Pattern which will match the start of the license text
 	 */

--- a/src/main/java/org/spdx/utility/compare/SpdxComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxComparer.java
@@ -1142,7 +1142,7 @@ public class SpdxComparer {
 	 * @param collectionA
 	 * @param collectionB
 	 * @throws InvalidSPDXAnalysisException 
-	 * @returnt true if the collections all contain equivalent items
+	 * @return true if the collections all contain equivalent items
 	 */
 	public static boolean collectionsEquivalent(Collection<? extends ModelObject> collectionA, Collection<? extends ModelObject> collectionB) throws InvalidSPDXAnalysisException {
 		if (Objects.isNull(collectionA)) {

--- a/src/main/java/org/spdx/utility/compare/SpdxPackageComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxPackageComparer.java
@@ -140,7 +140,6 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	 * Add a package to the comparer and performs the comparison to any existing documents
 	 * @param spdxDocument document containing the package
 	 * @param spdxPackage packaged to be added
-	 * @param licenseXlationMap A mapping between the license IDs from licenses in fileA to fileB
 	 * @throws SpdxCompareException 
 	 * @throws InvalidSPDXAnalysisException 
 	 */

--- a/src/main/java/org/spdx/utility/compare/SpdxSnippetComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxSnippetComparer.java
@@ -63,10 +63,6 @@ public class SpdxSnippetComparer extends SpdxItemComparer {
 	 * Add a snippet to the comparer and performs the comparison to any existing documents
 	 * @param spdxDocument document containing the package
 	 * @param snippet snippet to be added
-	 * @param licenseXlationMap A mapping between the license IDs from licenses in fileA to fileB
-	 * @throws SpdxCompareException 
-	 * @param spdxDocument
-	 * @param snippet
 	 * @throws InvalidSPDXAnalysisException 
 	 */
 	public void addDocumentSnippet(SpdxDocument spdxDocument,

--- a/src/main/java/org/spdx/utility/verificationcode/VerificationCodeGenerator.java
+++ b/src/main/java/org/spdx/utility/verificationcode/VerificationCodeGenerator.java
@@ -226,7 +226,6 @@ public class VerificationCodeGenerator {
 	}
 	/**
 	 * @param sourceDirectory
-	 * @param skippedFiles
 	 * @param modelStore where the resultant VerificationCode is store
 	 * @param documentUri document URI where the VerificationCode is stored
 	 * @return


### PR DESCRIPTION
The maven-javadoc-plugin was outputting a lot of errors, so I fixed it.
However, it was difficult to fix the warnings immediately, so I left them as they were. For example, this does NOT include a fix for the @param tag with an empty description. I'd like to leave these fixes to @goneall, if possible.

Also, I updated the maven-javadoc-plugin because it terminated abnormally and failed to compile on my environment, due to [MJAVADOC-488](https://issues.apache.org/jira/browse/MJAVADOC-488)