### PR TITLE
Add purl as a standard external ref type

### DIFF
--- a/resources/listedexternaltypes/listedreferencetypes.properties
+++ b/resources/listedexternaltypes/listedreferencetypes.properties
@@ -1,4 +1,4 @@
 # Properties file for listed reference types as described in the SPDX specification appendix
 #
 # List of all reference types separated by comma's
-listedReferenceTypes=cpe22Type,cpe23Type,maven-central,npm,nuget,bower,debian
+listedReferenceTypes=cpe22Type,cpe23Type,maven-central,npm,nuget,bower,debian,purl


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>