### PR TITLE
Fix download location regular expression

### DIFF
--- a/src/main/java/org/spdx/library/SpdxConstants.java
+++ b/src/main/java/org/spdx/library/SpdxConstants.java
@@ -360,7 +360,7 @@ public class SpdxConstants {
 	
 	// Download Location Format
 	private static final String SUPPORTED_DOWNLOAD_REPOS = "(git|hg|svn|bzr)";
-	private static final String URL_PATTERN = "(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/|ssh:\\/\\/|git:\\/\\/|svn:\\/\\/|sftp:\\/\\/|ftp:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+){0,100}\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)";
+	private static final String URL_PATTERN = "(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/|ssh:\\/\\/|git:\\/\\/|svn:\\/\\/|sftp:\\/\\/|ftp:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+){0,100}\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?";
 	private static final String GIT_PATTERN = "(git\\+git@[a-zA-Z0-9\\.]+:[a-zA-Z0-9/\\\\.@]+)";
 	private static final String BAZAAR_PATTERN = "(bzr\\+lp:[a-zA-Z0-9\\.]+)";
 	public static final Pattern DOWNLOAD_LOCATION_PATTERN = Pattern.compile("^(NONE|NOASSERTION|(("+SUPPORTED_DOWNLOAD_REPOS+"\\+)?"+URL_PATTERN+")|"+GIT_PATTERN+"|"+BAZAAR_PATTERN+")$", Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
* fixed tailing slash not being required when there is no sub-path

before
* google.com/ (valid)
* google.com  (invalid)

after
* google.com/ (valid)
* google.com  (valid)

Resolved https://github.com/spdx/tools-java/issues/38

Signed-off-by: riyenas0925 <riyenas0925@gmail.com>