### PR TITLE
Add swh to known listed reference types

### DIFF
--- a/resources/listedexternaltypes/listedreferencetypes.properties
+++ b/resources/listedexternaltypes/listedreferencetypes.properties
@@ -1,4 +1,4 @@
 # Properties file for listed reference types as described in the SPDX specification appendix
 #
 # List of all reference types separated by comma's
-listedReferenceTypes=cpe22Type,cpe23Type,maven-central,npm,nuget,bower,debian,purl
+listedReferenceTypes=cpe22Type,cpe23Type,maven-central,npm,nuget,bower,debian,purl,swh


### PR DESCRIPTION
swh was added in version 2.1 of the spec - this PR adds swh to the list of known reference types

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>