### PR TITLE
Update log4j version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
     	<groupId>org.apache.logging.log4j</groupId>
     	<artifactId>log4j-slf4j-impl</artifactId>
-    	<version>2.10.0</version>
+    	<version>2.15.0</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This is to safeguard users of `java-spdx-library` against a vulnerability (CVE-2021-44228) which could potentially allow remote code execution.

Signed-off-by: Sebastian Crane <seabass-labrax@gmx.com>