### PR TITLE
Fix a typo in the reference category enumerations

### DIFF
--- a/src/main/java/org/spdx/library/model/enumerations/ReferenceCategory.java
+++ b/src/main/java/org/spdx/library/model/enumerations/ReferenceCategory.java
@@ -30,7 +30,7 @@ public enum ReferenceCategory implements IndividualUriValue {
 	PACKAGE_MANAGER("referenceCategory_packageManager"),
 	SECURITY("referenceCategory_security"),
 	OTHER("referenceCategory_other"),
-	PERSISTENT_ID("referenceCategory_persistenId"),
+	PERSISTENT_ID("referenceCategory_persistentId"),
 	MISSING("invalid_missing")
 	;
 


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>