### PR TITLE
Add dashes as an allowed character for git download URLs

### DIFF
--- a/src/main/java/org/spdx/library/SpdxConstants.java
+++ b/src/main/java/org/spdx/library/SpdxConstants.java
@@ -366,8 +366,8 @@ public class SpdxConstants {
 	// Download Location Format
 	private static final String SUPPORTED_DOWNLOAD_REPOS = "(git|hg|svn|bzr)";
 	private static final String URL_PATTERN = "(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/|ssh:\\/\\/|git:\\/\\/|svn:\\/\\/|sftp:\\/\\/|ftp:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+){0,100}\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?";
-	private static final String GIT_PATTERN = "(git\\+git@[a-zA-Z0-9\\.]+:[a-zA-Z0-9/\\\\.@]+)";
-	private static final String BAZAAR_PATTERN = "(bzr\\+lp:[a-zA-Z0-9\\.]+)";
+	private static final String GIT_PATTERN = "(git\\+git@[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9/\\\\.@\\-]+)";
+	private static final String BAZAAR_PATTERN = "(bzr\\+lp:[a-zA-Z0-9\\.\\-]+)";
 	public static final Pattern DOWNLOAD_LOCATION_PATTERN = Pattern.compile("^(NONE|NOASSERTION|(("+SUPPORTED_DOWNLOAD_REPOS+"\\+)?"+URL_PATTERN+")|"+GIT_PATTERN+"|"+BAZAAR_PATTERN+")$", Pattern.CASE_INSENSITIVE);
 
 	// License list version Format

--- a/src/test/java/org/spdx/library/SpdxVerificationHelperTest.java
+++ b/src/test/java/org/spdx/library/SpdxVerificationHelperTest.java
@@ -172,6 +172,8 @@ public class SpdxVerificationHelperTest extends TestCase {
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709")));
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("git+https://git.myproject.org/MyProject.git@master#/src/MyClass.cpp")));
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("git+https://git.myproject.org/MyProject@da39a3ee5e6b4b0d3255bfef95601890afd80709#lib/variable.rb")));
+		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("git+git@github.com:myorg/my-repo.git")));
+		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("git+git@github.com:my-org/myrepo.git")));
 		// Mercurial
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("hg+http://hg.myproject.org/MyProject")));
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("hg+https://hg.myproject.org/MyProject")));


### PR DESCRIPTION
Fixes #78

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>