### PR TITLE
Override equals for IndividualUriValues

### DIFF
--- a/src/main/java/org/spdx/library/model/ExternalDocumentRef.java
+++ b/src/main/java/org/spdx/library/model/ExternalDocumentRef.java
@@ -224,6 +224,19 @@ public class ExternalDocumentRef extends ModelObject implements Comparable<Exter
 						public String getIndividualURI() {
 							return documentNamespace;
 						}
+						
+						@Override
+						public boolean equals(Object compare) {
+							if (!(compare instanceof IndividualUriValue)) {
+								return false;
+							}
+							return ((IndividualUriValue)compare).getIndividualURI().equals(documentNamespace);
+						}
+						
+						@Override
+						public int hashCode() {
+							return documentNamespace.hashCode();
+						}
 			});
 		}
 		return this;

--- a/src/main/java/org/spdx/library/model/ExternalDocumentRef.java
+++ b/src/main/java/org/spdx/library/model/ExternalDocumentRef.java
@@ -226,16 +226,13 @@ public class ExternalDocumentRef extends ModelObject implements Comparable<Exter
 						}
 						
 						@Override
-						public boolean equals(Object compare) {
-							if (!(compare instanceof IndividualUriValue)) {
-								return false;
-							}
-							return ((IndividualUriValue)compare).getIndividualURI().equals(documentNamespace);
+						public boolean equals(Object comp) {
+							return SimpleUriValue.isIndividualUriValueEquals(this, comp);
 						}
-						
+
 						@Override
 						public int hashCode() {
-							return documentNamespace.hashCode();
+							return SimpleUriValue.getIndividualUriValueHash(this);
 						}
 			});
 		}

--- a/src/main/java/org/spdx/library/model/ExternalSpdxElement.java
+++ b/src/main/java/org/spdx/library/model/ExternalSpdxElement.java
@@ -332,4 +332,17 @@ public class ExternalSpdxElement extends SpdxElement implements IndividualUriVal
 	public Optional<String> getName() throws InvalidSPDXAnalysisException {
 		return Optional.empty();
 	}
+	
+	@Override
+	public boolean equals(Object comp) {
+		if (!(comp instanceof IndividualUriValue)) {
+			return false;
+		}
+		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+	}
+
+	@Override
+	public int hashCode() {
+		return 11 ^ this.getIndividualURI().hashCode();
+	}
 }

--- a/src/main/java/org/spdx/library/model/ExternalSpdxElement.java
+++ b/src/main/java/org/spdx/library/model/ExternalSpdxElement.java
@@ -335,14 +335,11 @@ public class ExternalSpdxElement extends SpdxElement implements IndividualUriVal
 	
 	@Override
 	public boolean equals(Object comp) {
-		if (!(comp instanceof IndividualUriValue)) {
-			return false;
-		}
-		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+		return SimpleUriValue.isIndividualUriValueEquals(this, comp);
 	}
 
 	@Override
 	public int hashCode() {
-		return 11 ^ this.getIndividualURI().hashCode();
+		return SimpleUriValue.getIndividualUriValueHash(this);
 	}
 }

--- a/src/main/java/org/spdx/library/model/SimpleUriValue.java
+++ b/src/main/java/org/spdx/library/model/SimpleUriValue.java
@@ -93,10 +93,10 @@ public class SimpleUriValue implements IndividualUriValue {
 	
 	@Override
 	public boolean equals(Object comp) {
-		if (!(comp instanceof SimpleUriValue)) {
+		if (!(comp instanceof IndividualUriValue)) {
 			return false;
 		}
-		return Objects.equals(this.uri, ((SimpleUriValue)comp).getIndividualURI());
+		return Objects.equals(this.uri, ((IndividualUriValue)comp).getIndividualURI());
 	}
 
 	@Override

--- a/src/main/java/org/spdx/library/model/SimpleUriValue.java
+++ b/src/main/java/org/spdx/library/model/SimpleUriValue.java
@@ -44,6 +44,27 @@ public class SimpleUriValue implements IndividualUriValue {
 	
 	private String uri;
 
+	/**
+	 * returns hash based on URI of the IndividualUriValue
+	 * @param individualUri IndividualUriValue to obtain a hash from
+	 * @return hash based on URI of the IndividualUriValue
+	 */
+	public static int getIndividualUriValueHash(IndividualUriValue individualUri) {
+		return 11 ^ individualUri.getIndividualURI().hashCode();
+	}
+	
+	/**
+	 * Compares an object to an individual URI and returns true if the URI values are equal
+	 * @param individualUri IndividualUriValue to compare
+	 * @param comp Object to compare
+	 * @return true if the individualUri has the same URI as comp and comp is of type IndividualUriValue
+	 */
+	public static boolean isIndividualUriValueEquals(IndividualUriValue individualUri, Object comp) {
+		if (!(comp instanceof IndividualUriValue)) {
+			return false;
+		}
+		return Objects.equals(individualUri.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+	}
 
 	public SimpleUriValue(IndividualUriValue fromIndividualValue) throws InvalidSPDXAnalysisException {
 		this(fromIndividualValue.getIndividualURI());
@@ -93,14 +114,11 @@ public class SimpleUriValue implements IndividualUriValue {
 	
 	@Override
 	public boolean equals(Object comp) {
-		if (!(comp instanceof IndividualUriValue)) {
-			return false;
-		}
-		return Objects.equals(this.uri, ((IndividualUriValue)comp).getIndividualURI());
+		return isIndividualUriValueEquals(this, comp);
 	}
 
 	@Override
 	public int hashCode() {
-		return 11 ^ this.uri.hashCode();
+		return getIndividualUriValueHash(this);
 	}
 }

--- a/src/main/java/org/spdx/library/model/SpdxConstantElement.java
+++ b/src/main/java/org/spdx/library/model/SpdxConstantElement.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.SpdxConstants;
@@ -113,6 +114,19 @@ public abstract class SpdxConstantElement extends SpdxElement implements Individ
 	@Override
 	public SpdxElement setName(String name) throws InvalidSPDXAnalysisException {
 		throw new RuntimeException("Can not set name for NONE and NOASSERTION SPDX Elements");
+	}
+	
+	@Override
+	public boolean equals(Object comp) {
+		if (!(comp instanceof IndividualUriValue)) {
+			return false;
+		}
+		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+	}
+
+	@Override
+	public int hashCode() {
+		return 11 ^ this.getIndividualURI().hashCode();
 	}
 
 }

--- a/src/main/java/org/spdx/library/model/SpdxConstantElement.java
+++ b/src/main/java/org/spdx/library/model/SpdxConstantElement.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.SpdxConstants;
@@ -118,15 +117,11 @@ public abstract class SpdxConstantElement extends SpdxElement implements Individ
 	
 	@Override
 	public boolean equals(Object comp) {
-		if (!(comp instanceof IndividualUriValue)) {
-			return false;
-		}
-		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+		return SimpleUriValue.isIndividualUriValueEquals(this, comp);
 	}
 
 	@Override
 	public int hashCode() {
-		return 11 ^ this.getIndividualURI().hashCode();
+		return SimpleUriValue.getIndividualUriValueHash(this);
 	}
-
 }

--- a/src/main/java/org/spdx/library/model/SpdxNoAssertionElement.java
+++ b/src/main/java/org/spdx/library/model/SpdxNoAssertionElement.java
@@ -37,7 +37,6 @@ import org.spdx.storage.IModelStore;
 public class SpdxNoAssertionElement extends SpdxConstantElement {
 
 	public static final String NOASSERTION_ELEMENT_ID = "NOASSERTION";
-	public static final int NOASSERTION_ELEMENT_HASHCODE = 491;
 	
 	/**
 	 * Create a None element with default model store and document URI
@@ -60,16 +59,6 @@ public class SpdxNoAssertionElement extends SpdxConstantElement {
 	@Override
 	public String toString() {
 		return SpdxConstants.NOASSERTION_VALUE;
-	}
-	
-	@Override
-	public int hashCode() {
-		return NOASSERTION_ELEMENT_HASHCODE;
-	}
-	
-	@Override
-	public boolean equals(Object o) {
-		return o instanceof SpdxNoAssertionElement;
 	}
 	
 	@Override

--- a/src/main/java/org/spdx/library/model/SpdxNoneElement.java
+++ b/src/main/java/org/spdx/library/model/SpdxNoneElement.java
@@ -37,7 +37,6 @@ import org.spdx.storage.IModelStore;
 public class SpdxNoneElement extends SpdxConstantElement {
 	
 	public static final String NONE_ELEMENT_ID = "NONE";
-	public static final int NONE_ELEMENT_HASHCODE = 433;
 	
 	/**
 	 * Create a None element with default model store and document URI
@@ -60,16 +59,6 @@ public class SpdxNoneElement extends SpdxConstantElement {
 	@Override
 	public String toString() {
 		return SpdxConstants.NONE_VALUE;
-	}
-	
-	@Override
-	public int hashCode() {
-		return NONE_ELEMENT_HASHCODE;
-	}
-	
-	@Override
-	public boolean equals(Object o) {
-		return o instanceof SpdxNoneElement;
 	}
 	
 	@Override

--- a/src/main/java/org/spdx/library/model/license/ExternalExtractedLicenseInfo.java
+++ b/src/main/java/org/spdx/library/model/license/ExternalExtractedLicenseInfo.java
@@ -293,4 +293,17 @@ public class ExternalExtractedLicenseInfo extends ExtractedLicenseInfo implement
 		throw new InvalidSPDXAnalysisException("Can not set name for an external LicenseRef.  "
 				+ "Changes to the license need to be made within the document containing the license.");
 	}
+	
+	@Override
+	public boolean equals(Object comp) {
+		if (!(comp instanceof IndividualUriValue)) {
+			return false;
+		}
+		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+	}
+
+	@Override
+	public int hashCode() {
+		return 11 ^ this.getIndividualURI().hashCode();
+	}
 }

--- a/src/main/java/org/spdx/library/model/license/ExternalExtractedLicenseInfo.java
+++ b/src/main/java/org/spdx/library/model/license/ExternalExtractedLicenseInfo.java
@@ -34,6 +34,7 @@ import org.spdx.library.model.ExternalDocumentRef;
 import org.spdx.library.model.ExternalSpdxElement;
 import org.spdx.library.model.IndividualUriValue;
 import org.spdx.library.model.ModelObject;
+import org.spdx.library.model.SimpleUriValue;
 import org.spdx.storage.IModelStore;
 
 /**
@@ -296,14 +297,11 @@ public class ExternalExtractedLicenseInfo extends ExtractedLicenseInfo implement
 	
 	@Override
 	public boolean equals(Object comp) {
-		if (!(comp instanceof IndividualUriValue)) {
-			return false;
-		}
-		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+		return SimpleUriValue.isIndividualUriValueEquals(this, comp);
 	}
 
 	@Override
 	public int hashCode() {
-		return 11 ^ this.getIndividualURI().hashCode();
+		return SimpleUriValue.getIndividualUriValueHash(this);
 	}
 }

--- a/src/main/java/org/spdx/library/model/license/SpdxNoAssertionLicense.java
+++ b/src/main/java/org/spdx/library/model/license/SpdxNoAssertionLicense.java
@@ -18,11 +18,11 @@ package org.spdx.library.model.license;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.SpdxConstants;
 import org.spdx.library.model.IndividualUriValue;
+import org.spdx.library.model.SimpleUriValue;
 import org.spdx.storage.IModelStore;
 
 /**
@@ -57,15 +57,12 @@ public class SpdxNoAssertionLicense extends AnyLicenseInfo implements Individual
 	
 	@Override
 	public boolean equals(Object comp) {
-		if (!(comp instanceof IndividualUriValue)) {
-			return false;
-		}
-		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+		return SimpleUriValue.isIndividualUriValueEquals(this, comp);
 	}
 
 	@Override
 	public int hashCode() {
-		return 11 ^ this.getIndividualURI().hashCode();
+		return SimpleUriValue.getIndividualUriValueHash(this);
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/spdx/library/model/license/SpdxNoAssertionLicense.java
+++ b/src/main/java/org/spdx/library/model/license/SpdxNoAssertionLicense.java
@@ -18,6 +18,7 @@ package org.spdx.library.model.license;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.SpdxConstants;
@@ -46,8 +47,6 @@ public class SpdxNoAssertionLicense extends AnyLicenseInfo implements Individual
 		super(modelStore, documentUri, NOASSERTION_LICENSE_ID, null, true);
 	}
 	
-	static final int NO_ASSERTION_HASHCODE = 89;	// prime number - all NoAssertion licenses should have the same hashcode
-
 	/* (non-Javadoc)
 	 * @see org.spdx.rdfparser.license.AnyLicenseInfo#toString()
 	 */
@@ -57,19 +56,16 @@ public class SpdxNoAssertionLicense extends AnyLicenseInfo implements Individual
 	}
 	
 	@Override
-	public int hashCode() {
-		return NO_ASSERTION_HASHCODE;
+	public boolean equals(Object comp) {
+		if (!(comp instanceof IndividualUriValue)) {
+			return false;
+		}
+		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
 	}
 
-	/* (non-Javadoc)
-	 * @see org.spdx.rdfparser.license.AnyLicenseInfo#equals(java.lang.Object)
-	 */
 	@Override
-	public boolean equals(Object o) {
-		if (o == this) {
-			return true;
-		}
-		return (o instanceof SpdxNoAssertionLicense);		// All instances of this type are considered equal
+	public int hashCode() {
+		return 11 ^ this.getIndividualURI().hashCode();
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/spdx/library/model/license/SpdxNoneLicense.java
+++ b/src/main/java/org/spdx/library/model/license/SpdxNoneLicense.java
@@ -18,11 +18,11 @@ package org.spdx.library.model.license;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.SpdxConstants;
 import org.spdx.library.model.IndividualUriValue;
+import org.spdx.library.model.SimpleUriValue;
 import org.spdx.storage.IModelStore;
 
 /**
@@ -57,15 +57,12 @@ public class SpdxNoneLicense extends AnyLicenseInfo implements IndividualUriValu
 	
 	@Override
 	public boolean equals(Object comp) {
-		if (!(comp instanceof IndividualUriValue)) {
-			return false;
-		}
-		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
+		return SimpleUriValue.isIndividualUriValueEquals(this, comp);
 	}
 
 	@Override
 	public int hashCode() {
-		return 11 ^ this.getIndividualURI().hashCode();
+		return SimpleUriValue.getIndividualUriValueHash(this);
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/spdx/library/model/license/SpdxNoneLicense.java
+++ b/src/main/java/org/spdx/library/model/license/SpdxNoneLicense.java
@@ -18,6 +18,7 @@ package org.spdx.library.model.license;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.SpdxConstants;
@@ -31,7 +32,6 @@ import org.spdx.storage.IModelStore;
  */
 public class SpdxNoneLicense extends AnyLicenseInfo implements IndividualUriValue {
 	
-	static final int NONE_LICENSE_HASHCODE = 147; // prime number - all none licenses should have the same hashcde
 	static final String NONE_LICENSE_ID = "SPDX_NONE_LICENSE";
 	
 	/**
@@ -56,19 +56,16 @@ public class SpdxNoneLicense extends AnyLicenseInfo implements IndividualUriValu
 	}
 	
 	@Override
-	public int hashCode() {
-		return NONE_LICENSE_HASHCODE;
+	public boolean equals(Object comp) {
+		if (!(comp instanceof IndividualUriValue)) {
+			return false;
+		}
+		return Objects.equals(this.getIndividualURI(), ((IndividualUriValue)comp).getIndividualURI());
 	}
 
-	/* (non-Javadoc)
-	 * @see org.spdx.rdfparser.license.AnyLicenseInfo#equals(java.lang.Object)
-	 */
 	@Override
-	public boolean equals(Object o) {
-		if (o == this) {
-			return true;
-		}
-		return (o instanceof SpdxNoneLicense);		// All Instances of this type are considered equal
+	public int hashCode() {
+		return 11 ^ this.getIndividualURI().hashCode();
 	}
 
 	/* (non-Javadoc)

--- a/src/test/java/org/spdx/library/model/IndividualUriValueTest.java
+++ b/src/test/java/org/spdx/library/model/IndividualUriValueTest.java
@@ -1,0 +1,92 @@
+package org.spdx.library.model;
+
+import org.spdx.library.InvalidSPDXAnalysisException;
+import org.spdx.library.ModelCopyManager;
+import org.spdx.library.SpdxConstants;
+import org.spdx.library.model.enumerations.ChecksumAlgorithm;
+import org.spdx.library.model.license.ExternalExtractedLicenseInfo;
+import org.spdx.library.model.license.SpdxNoAssertionLicense;
+import org.spdx.library.model.license.SpdxNoneLicense;
+import org.spdx.storage.IModelStore;
+import org.spdx.storage.simple.InMemSpdxStore;
+
+import junit.framework.TestCase;
+
+public class IndividualUriValueTest extends TestCase {
+	
+	static final String SHA1_CHECKSUM = "399e50ed82067fc273ed02495fbdb149a667ebe9";
+
+	protected void setUp() throws Exception {
+		super.setUp();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+	}
+	
+	// Test if a simple URI value is equal to the ExternalExtracedLicenseInfo with the same URI value
+	public void testEqualUriValueExternalExtractedLicenseInfo() throws InvalidSPDXAnalysisException {
+		IModelStore modelStore = new InMemSpdxStore();
+		ModelCopyManager copyManager = new ModelCopyManager();
+		String id = SpdxConstants.NON_STD_LICENSE_ID_PRENUM+"ID";
+		String namespace = "http://example.namespace";
+		String externalDocId = SpdxConstants.EXTERNAL_DOC_REF_PRENUM + "externalDoc";
+		String externalDocNamespace = "http://example.external.namespace";
+		ExternalDocumentRef edr = new ExternalDocumentRef(modelStore, namespace, externalDocId, copyManager, true);
+		edr.setChecksum(edr.createChecksum(ChecksumAlgorithm.SHA1, SHA1_CHECKSUM));
+		edr.setSpdxDocumentNamespace(externalDocNamespace);
+		ExternalExtractedLicenseInfo eel = new ExternalExtractedLicenseInfo(modelStore, namespace, externalDocId + ":" + id, copyManager, true);
+		SimpleUriValue suv = new SimpleUriValue(externalDocNamespace + "#" + id);
+		assertTrue(eel.equals(suv));
+		assertTrue(suv.equals(eel));
+	}
+
+	// Test if a simple URI value is equal to the ExternalSpdxElement with the same URI value
+	public void testEqualUriValueExternalSpdxElement() throws InvalidSPDXAnalysisException {
+		IModelStore modelStore = new InMemSpdxStore();
+		ModelCopyManager copyManager = new ModelCopyManager();
+		String id = SpdxConstants.SPDX_ELEMENT_REF_PRENUM+"ID";
+		String namespace = "http://example.namespace";
+		String externalDocId = SpdxConstants.EXTERNAL_DOC_REF_PRENUM + "externalDoc";
+		String externalDocNamespace = "http://example.external.namespace";
+		ExternalDocumentRef edr = new ExternalDocumentRef(modelStore, namespace, externalDocId, copyManager, true);
+		edr.setChecksum(edr.createChecksum(ChecksumAlgorithm.SHA1, SHA1_CHECKSUM));
+		edr.setSpdxDocumentNamespace(externalDocNamespace);
+		ExternalSpdxElement ese = new ExternalSpdxElement(modelStore, namespace, externalDocId + ":" + id, copyManager, true);
+		SimpleUriValue suv = new SimpleUriValue(externalDocNamespace + "#" + id);
+		assertTrue(ese.equals(suv));
+		assertTrue(suv.equals(ese));
+	}
+	
+	// Test if a simple URI value is equal to the NoAssertionLicense with the same URI value
+	public void testEqualUriValueNoAssertionLicense() throws InvalidSPDXAnalysisException {
+		SpdxNoAssertionLicense nal = new SpdxNoAssertionLicense();
+		SimpleUriValue suv = new SimpleUriValue(SpdxConstants.URI_VALUE_NOASSERTION);
+		assertTrue(nal.equals(suv));
+		assertTrue(suv.equals(nal));
+	}
+	
+	// Test if a simple URI value is equal to the NoneLicense with the same URI value
+	public void testEqualUriValueNoneLicense() throws InvalidSPDXAnalysisException {
+		SpdxNoneLicense nl = new SpdxNoneLicense();
+		SimpleUriValue suv = new SimpleUriValue(SpdxConstants.URI_VALUE_NONE);
+		assertTrue(nl.equals(suv));
+		assertTrue(suv.equals(nl));
+	}
+	
+	// Test if a simple URI value is equal to the SpdxNoneElement with the same URI value
+	public void testEqualUriValueNone() throws InvalidSPDXAnalysisException {
+		SpdxNoneElement ne = new SpdxNoneElement();
+		SimpleUriValue suv = new SimpleUriValue(SpdxConstants.URI_VALUE_NONE);
+		assertTrue(ne.equals(suv));
+		assertTrue(suv.equals(ne));
+	}
+	
+	// Test if a simple URI value is equal to the SpdxNoAssertionElement with the same URI value
+	public void testEqualUriValueNoAssertion() throws InvalidSPDXAnalysisException {
+		SpdxNoAssertionElement na = new SpdxNoAssertionElement();
+		SimpleUriValue suv = new SimpleUriValue(SpdxConstants.URI_VALUE_NOASSERTION);
+		assertTrue(na.equals(suv));
+		assertTrue(suv.equals(na));
+	}
+}

--- a/src/test/java/org/spdx/library/model/RelationshipTest.java
+++ b/src/test/java/org/spdx/library/model/RelationshipTest.java
@@ -19,15 +19,23 @@ package org.spdx.library.model;
 
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 
 import org.spdx.library.DefaultModelStore;
 import org.spdx.library.InvalidSPDXAnalysisException;
+import org.spdx.library.ModelCopyManager;
 import org.spdx.library.SpdxConstants;
+import org.spdx.library.Version;
 import org.spdx.library.model.enumerations.AnnotationType;
 import org.spdx.library.model.enumerations.ChecksumAlgorithm;
 import org.spdx.library.model.enumerations.RelationshipType;
+import org.spdx.library.model.license.AnyLicenseInfo;
+import org.spdx.library.model.license.LicenseInfoFactory;
+import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
+import org.spdx.storage.simple.InMemSpdxStore;
 
 import junit.framework.TestCase;
 
@@ -196,6 +204,49 @@ public class RelationshipTest extends TestCase {
 		compare.setRelationshipType(RelationshipType.ANCESTOR_OF);
 		assertTrue(relationship.compareTo(compare) > 0);
 		assertTrue(compare.compareTo(relationship) < 0);
+	}
+	
+	/**
+	 * Test if the DocumentDescribes relationship produces more than one relationship
+	 * see issue #115 for context
+	 * @throws InvalidSPDXAnalysisException
+	 */
+	public void testDocumentDescribes() throws InvalidSPDXAnalysisException {
+		String documentUri = "https://someuri";
+        ModelCopyManager copyManager = new ModelCopyManager();
+        IModelStore modelStore = new InMemSpdxStore();
+        SpdxDocument document = SpdxModelFactory.createSpdxDocument(modelStore, documentUri, copyManager);
+        document.setSpecVersion(Version.TWO_POINT_THREE_VERSION);
+        document.setName("SPDX-tool-test");
+        Checksum sha1Checksum = Checksum.create(modelStore, documentUri, ChecksumAlgorithm.SHA1, "d6a770ba38583ed4bb4525bd96e50461655d2758");
+        AnyLicenseInfo concludedLicense = LicenseInfoFactory.parseSPDXLicenseString("LGPL-2.0-only OR LicenseRef-2");
+        SpdxFile fileA = document.createSpdxFile("SPDXRef-fileA", "./package/fileA.c", concludedLicense,
+                        Arrays.asList(new AnyLicenseInfo[0]), "Copyright 2008-2010 John Smith", sha1Checksum)
+                .build();
+        SpdxFile fileB = document.createSpdxFile("SPDXRef-fileB", "./package/fileB.c", concludedLicense,
+        		Arrays.asList(new AnyLicenseInfo[0]), "Copyright 2008-2010 John Smith", sha1Checksum)
+                .build();
+        document.getDocumentDescribes().addAll(Arrays.asList(new SpdxElement[] {fileA, fileB}));
+        assertEquals(2, document.getDocumentDescribes().size());
+        assertTrue(document.getDocumentDescribes().contains(fileA));
+        assertTrue(document.getDocumentDescribes().contains(fileB));
+        Collection<Relationship> docrels = document.getRelationships();
+        assertEquals(2, docrels.size());
+        boolean foundFileA = false;
+        boolean foundFileB = false;
+        for (Relationship rel:docrels) {
+        	assertEquals(RelationshipType.DESCRIBES, rel.getRelationshipType());
+        	SpdxElement elem = rel.getRelatedSpdxElement().get();
+        	if (fileA.equals(elem)) {
+        		foundFileA = true;
+        	} else if (fileB.equals(elem)) {
+        		foundFileB = true;
+        	} else {
+        		fail("Unexpected relationship");
+        	}
+        }
+    	assertTrue(foundFileA);
+    	assertTrue(foundFileB);
 	}
 
 }

--- a/src/test/java/org/spdx/library/model/RelationshipTest.java
+++ b/src/test/java/org/spdx/library/model/RelationshipTest.java
@@ -19,23 +19,15 @@ package org.spdx.library.model;
 
 
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 
 import org.spdx.library.DefaultModelStore;
 import org.spdx.library.InvalidSPDXAnalysisException;
-import org.spdx.library.ModelCopyManager;
 import org.spdx.library.SpdxConstants;
-import org.spdx.library.Version;
 import org.spdx.library.model.enumerations.AnnotationType;
 import org.spdx.library.model.enumerations.ChecksumAlgorithm;
 import org.spdx.library.model.enumerations.RelationshipType;
-import org.spdx.library.model.license.AnyLicenseInfo;
-import org.spdx.library.model.license.LicenseInfoFactory;
-import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
-import org.spdx.storage.simple.InMemSpdxStore;
 
 import junit.framework.TestCase;
 
@@ -204,49 +196,6 @@ public class RelationshipTest extends TestCase {
 		compare.setRelationshipType(RelationshipType.ANCESTOR_OF);
 		assertTrue(relationship.compareTo(compare) > 0);
 		assertTrue(compare.compareTo(relationship) < 0);
-	}
-	
-	/**
-	 * Test if the DocumentDescribes relationship produces more than one relationship
-	 * see issue #115 for context
-	 * @throws InvalidSPDXAnalysisException
-	 */
-	public void testDocumentDescribes() throws InvalidSPDXAnalysisException {
-		String documentUri = "https://someuri";
-        ModelCopyManager copyManager = new ModelCopyManager();
-        IModelStore modelStore = new InMemSpdxStore();
-        SpdxDocument document = SpdxModelFactory.createSpdxDocument(modelStore, documentUri, copyManager);
-        document.setSpecVersion(Version.TWO_POINT_THREE_VERSION);
-        document.setName("SPDX-tool-test");
-        Checksum sha1Checksum = Checksum.create(modelStore, documentUri, ChecksumAlgorithm.SHA1, "d6a770ba38583ed4bb4525bd96e50461655d2758");
-        AnyLicenseInfo concludedLicense = LicenseInfoFactory.parseSPDXLicenseString("LGPL-2.0-only OR LicenseRef-2");
-        SpdxFile fileA = document.createSpdxFile("SPDXRef-fileA", "./package/fileA.c", concludedLicense,
-                        Arrays.asList(new AnyLicenseInfo[0]), "Copyright 2008-2010 John Smith", sha1Checksum)
-                .build();
-        SpdxFile fileB = document.createSpdxFile("SPDXRef-fileB", "./package/fileB.c", concludedLicense,
-        		Arrays.asList(new AnyLicenseInfo[0]), "Copyright 2008-2010 John Smith", sha1Checksum)
-                .build();
-        document.getDocumentDescribes().addAll(Arrays.asList(new SpdxElement[] {fileA, fileB}));
-        assertEquals(2, document.getDocumentDescribes().size());
-        assertTrue(document.getDocumentDescribes().contains(fileA));
-        assertTrue(document.getDocumentDescribes().contains(fileB));
-        Collection<Relationship> docrels = document.getRelationships();
-        assertEquals(2, docrels.size());
-        boolean foundFileA = false;
-        boolean foundFileB = false;
-        for (Relationship rel:docrels) {
-        	assertEquals(RelationshipType.DESCRIBES, rel.getRelationshipType());
-        	SpdxElement elem = rel.getRelatedSpdxElement().get();
-        	if (fileA.equals(elem)) {
-        		foundFileA = true;
-        	} else if (fileB.equals(elem)) {
-        		foundFileB = true;
-        	} else {
-        		fail("Unexpected relationship");
-        	}
-        }
-    	assertTrue(foundFileA);
-    	assertTrue(foundFileB);
 	}
 
 }


### PR DESCRIPTION
This will cause any individual URI values to be equal if their URI's are equal.

Fixes #108

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>