### PR TITLE
Fail when creating an SPDX ID with a different type

### DIFF
--- a/src/main/java/org/spdx/library/model/ModelObject.java
+++ b/src/main/java/org/spdx/library/model/ModelObject.java
@@ -192,7 +192,12 @@ public abstract class ModelObject {
 		this.documentUri = documentUri;
 		this.id = id;
 		this.copyManager = copyManager;
-		if (!modelStore.exists(documentUri, id)) {
+		Optional<TypedValue> existing = modelStore.getTypedValue(documentUri, id);
+		if (existing.isPresent()) {
+			if (create && !existing.get().getType().equals(getType())) {
+				throw new SpdxIdInUseException("Can not create "+id+".  It is already in use with type "+existing.get().getType()+" which is incompatible with type "+getType());
+			}
+		} else {
 			if (create) {
 				modelStore.create(documentUri, id, getType());
 			} else {

--- a/src/test/java/org/spdx/library/model/ModelObjectTest.java
+++ b/src/test/java/org/spdx/library/model/ModelObjectTest.java
@@ -17,6 +17,8 @@
  */
 package org.spdx.library.model;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -858,11 +860,8 @@ public class ModelObjectTest extends TestCase {
 		SpdxFile file = new SpdxFile(store, docUri, TEST_ID, copyManager, true);
 		// the following should succeed since it is of the same type
 		SpdxFile fileb = new SpdxFile(store, docUri, TEST_ID, copyManager, true);
-		try {
+		assertThrows(SpdxIdInUseException.class, () -> {
 			Annotation annotation = new Annotation(store, docUri, TEST_ID, copyManager, true);
-			fail("Should not be able to create 2 different types using the same ID");
-		} catch (SpdxIdInUseException ex) {
-			// expected
-		}
+		});
 	}
 }

--- a/src/test/java/org/spdx/library/model/ModelObjectTest.java
+++ b/src/test/java/org/spdx/library/model/ModelObjectTest.java
@@ -848,4 +848,21 @@ public class ModelObjectTest extends TestCase {
 			// expected
 		}
 	}
+	
+	/**
+	 * Negative test for creating 2 model objects with incompatible types which should fail
+	 * @throws InvalidSPDXAnalysisException
+	 */
+	@SuppressWarnings("unused")
+	public void testCreatingIncompatible() throws InvalidSPDXAnalysisException {
+		SpdxFile file = new SpdxFile(store, docUri, TEST_ID, copyManager, true);
+		// the following should succeed since it is of the same type
+		SpdxFile fileb = new SpdxFile(store, docUri, TEST_ID, copyManager, true);
+		try {
+			Annotation annotation = new Annotation(store, docUri, TEST_ID, copyManager, true);
+			fail("Should not be able to create 2 different types using the same ID");
+		} catch (SpdxIdInUseException ex) {
+			// expected
+		}
+	}
 }


### PR DESCRIPTION
(mostly) Fixes issue #119 

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>