### PR TITLE
Improve parse exception error handling

### DIFF
--- a/src/main/java/org/spdx/library/model/license/LicenseExpressionParser.java
+++ b/src/main/java/org/spdx/library/model/license/LicenseExpressionParser.java
@@ -183,6 +183,8 @@ public class LicenseExpressionParser {
 					}
 					if (exceptionId.isPresent()) {
 						licenseException = LicenseInfoFactory.getListedExceptionById(exceptionId.get());
+					} else if (token.startsWith(SpdxConstants.NON_STD_LICENSE_ID_PRENUM)) {
+						throw new LicenseParserException("WITH must be followed by a license exception. "+token+" is a Listed License type.");
 					} else {
 						licenseException = (LicenseException) SpdxModelFactory.createModelObject(store, 
 								documentUri, token, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, copyManager);


### PR DESCRIPTION
Checks for LicenseRefs being used for exceptions

See https://github.com/spdx/tools-java/issues/73 for context.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>