### PR TITLE
Add an option to not copy license details in CopyManager

### DIFF
--- a/src/main/java/org/spdx/library/SpdxConstants.java
+++ b/src/main/java/org/spdx/library/SpdxConstants.java
@@ -135,7 +135,7 @@ public class SpdxConstants {
 			CLASS_POINTER_COMPOUNT_POINTER, CLASS_POINTER_LINE_CHAR_POINTER, CLASS_SINGLE_POINTER};
 	
 	// classes that use the listed license URI for their namespace
-	public static final String[] LISTED_LICENSE_URI_CLASSES = {CLASS_SPDX_LISTED_LICENSE, CLASS_SPDX_LICENSE_EXCEPTION};
+	public static final String[] LISTED_LICENSE_URI_CLASSES = {CLASS_SPDX_LISTED_LICENSE, CLASS_SPDX_LISTED_LICENSE_EXCEPTION};
 	
 	// Enumeration class names
 	public static final String ENUM_FILE_TYPE = "FileType";

--- a/src/main/java/org/spdx/library/model/SpdxModelFactory.java
+++ b/src/main/java/org/spdx/library/model/SpdxModelFactory.java
@@ -93,6 +93,7 @@ public class SpdxModelFactory {
 		typeToClass.put(SpdxConstants.CLASS_SPDX_LICENSE, License.class);
 		typeToClass.put(SpdxConstants.CLASS_SPDX_LISTED_LICENSE, SpdxListedLicense.class);
 		typeToClass.put(SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, LicenseException.class);
+		typeToClass.put(SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, ListedLicenseException.class);
 		typeToClass.put(SpdxConstants.CLASS_OR_LATER_OPERATOR, OrLaterOperator.class);
 		typeToClass.put(SpdxConstants.CLASS_WITH_EXCEPTION_OPERATOR, WithExceptionOperator.class);
 		typeToClass.put(SpdxConstants.CLASS_SPDX_FILE, SpdxFile.class);

--- a/src/main/java/org/spdx/library/model/license/LicenseExpressionParser.java
+++ b/src/main/java/org/spdx/library/model/license/LicenseExpressionParser.java
@@ -64,7 +64,7 @@ public class LicenseExpressionParser {
 		OPERATOR_MAP.put("with", Operator.WITH);
 	}
 	/**
-	 * Parses a license expression into an license for use in the RDF Parser
+	 * Parses a license expression into an license for use in the Model
 	 * @param expression Expression to be parsed
 	 * @param store Store containing any extractedLicenseInfos - if any extractedLicenseInfos by ID already exist, they will be used.  If
 	 * none exist for an ID, they will be added.  If null, the default model store will be used.
@@ -187,8 +187,8 @@ public class LicenseExpressionParser {
 					} else if (token.startsWith(SpdxConstants.NON_STD_LICENSE_ID_PRENUM)) {
 						throw new LicenseParserException("WITH must be followed by a license exception. "+token+" is a Listed License type.");
 					} else {
-						licenseException = (LicenseException) SpdxModelFactory.createModelObject(store, 
-								documentUri, token, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, copyManager);
+						licenseException = (ListedLicenseException) SpdxModelFactory.createModelObject(store, 
+								documentUri, token, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, copyManager);
 					}
 					AnyLicenseInfo operand = operandStack.pop();
 					if (operand == null) {

--- a/src/main/java/org/spdx/library/model/license/LicenseInfoFactory.java
+++ b/src/main/java/org/spdx/library/model/license/LicenseInfoFactory.java
@@ -148,7 +148,7 @@ public class LicenseInfoFactory {
 	 * @return the standard SPDX license exception or null if the ID is not in the SPDX license list
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	public static LicenseException getListedExceptionById(String id) throws InvalidSPDXAnalysisException {
+	public static ListedLicenseException getListedExceptionById(String id) throws InvalidSPDXAnalysisException {
 		return ListedLicenses.getListedLicenses().getListedExceptionById(id);
 	}
 

--- a/src/main/java/org/spdx/library/model/license/ListedLicenseException.java
+++ b/src/main/java/org/spdx/library/model/license/ListedLicenseException.java
@@ -86,6 +86,11 @@ public class ListedLicenseException extends LicenseException {
 		super(id, name, text);
 	}
 	
+	@Override 
+	public String getType() {
+		return SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION;
+	}
+	
 	/**
 	 * @param exceptionTextHtml
 	 * @throws InvalidSPDXAnalysisException

--- a/src/main/java/org/spdx/library/model/license/SimpleLicensingInfo.java
+++ b/src/main/java/org/spdx/library/model/license/SimpleLicensingInfo.java
@@ -40,16 +40,13 @@ import org.spdx.storage.IModelStore;
  */
 public abstract class SimpleLicensingInfo extends AnyLicenseInfo {
 	
-	Collection<CrossRef> crossRef;
 	/**
 	 * Open or create a model object with the default store and default document URI
 	 * @param id ID for this object - must be unique within the SPDX document
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	@SuppressWarnings("unchecked")
 	SimpleLicensingInfo(String id) throws InvalidSPDXAnalysisException {
 		super(id);
-		crossRef = (Collection<CrossRef>)(Collection<?>)this.getObjectPropertyValueSet(SpdxConstants.PROP_CROSS_REF, CrossRef.class);
         if (!(this instanceof IndividualUriValue)) {
             setPropertyValue(SpdxConstants.PROP_LICENSE_ID, id);  // Needs to be set as a property per spec
         }
@@ -64,12 +61,10 @@ public abstract class SimpleLicensingInfo extends AnyLicenseInfo {
 	 * @param create if true, create the license if it does not exist
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	@SuppressWarnings("unchecked")
 	SimpleLicensingInfo(IModelStore modelStore, String documentUri, String id, 
 			@Nullable ModelCopyManager copyManager, boolean create)
 			throws InvalidSPDXAnalysisException {
 		super(modelStore, documentUri, id, copyManager, create);
-		crossRef = (Collection<CrossRef>)(Collection<?>)this.getObjectPropertyValueSet(SpdxConstants.PROP_CROSS_REF, CrossRef.class);
 		if (!(this instanceof IndividualUriValue)) {
 		    setPropertyValue(SpdxConstants.PROP_LICENSE_ID, id);  // Needs to be set as a property per spec
 		}
@@ -141,9 +136,5 @@ public abstract class SimpleLicensingInfo extends AnyLicenseInfo {
 		} else {
 			setPropertyValue(SpdxConstants.RDFS_PROP_SEE_ALSO, seeAlsoUrl);
 		}
-	}
-	
-	public Collection<CrossRef> getCrossRef() throws InvalidSPDXAnalysisException {
-		return this.crossRef;
 	}
 }

--- a/src/main/java/org/spdx/library/model/license/SpdxListedLicense.java
+++ b/src/main/java/org/spdx/library/model/license/SpdxListedLicense.java
@@ -16,6 +16,7 @@
  */
 package org.spdx.library.model.license;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -40,13 +41,17 @@ import org.spdx.storage.IModelStore;
  */
 public class SpdxListedLicense extends License {
 	
+	Collection<CrossRef> crossRef;
+	
 	/**
 	 * Open or create a model object with the default store and default document URI
 	 * @param id ID for this object - must be unique within the SPDX document
 	 * @throws InvalidSPDXAnalysisException 
 	 */
+	@SuppressWarnings("unchecked")
 	public SpdxListedLicense(String id) throws InvalidSPDXAnalysisException {
 		super(id);
+		crossRef = (Collection<CrossRef>)(Collection<?>)this.getObjectPropertyValueSet(SpdxConstants.PROP_CROSS_REF, CrossRef.class);
 	}
 
 	/**
@@ -58,10 +63,12 @@ public class SpdxListedLicense extends License {
 	 * @param create if true, create the license if it does not exist
 	 * @throws InvalidSPDXAnalysisException 
 	 */
+	@SuppressWarnings("unchecked")
 	public SpdxListedLicense(IModelStore modelStore, String documentUri, String id, 
 			@Nullable ModelCopyManager copyManager, boolean create)
 			throws InvalidSPDXAnalysisException {
 		super(modelStore, documentUri, id, copyManager, create);
+		crossRef = (Collection<CrossRef>)(Collection<?>)this.getObjectPropertyValueSet(SpdxConstants.PROP_CROSS_REF, CrossRef.class);
 	}
 	
 	/**
@@ -79,6 +86,7 @@ public class SpdxListedLicense extends License {
 	 * @param deprecatedVersion License list version when this license was first deprecated (null if not deprecated)
 	 * @throws InvalidSPDXAnalysisException
 	 */
+	@SuppressWarnings("unchecked")
 	public SpdxListedLicense(String name, String id, String text, Collection<String> sourceUrl, String comments,
 			String standardLicenseHeader, String template, boolean osiApproved, Boolean fsfLibre, 
 			String licenseTextHtml, boolean isDeprecated, String deprecatedVersion) throws InvalidSPDXAnalysisException {
@@ -94,6 +102,7 @@ public class SpdxListedLicense extends License {
 		setLicenseTextHtml(licenseTextHtml);
 		setDeprecated(isDeprecated);
 		setDeprecatedVersion(deprecatedVersion);
+		crossRef = (Collection<CrossRef>)(Collection<?>)this.getObjectPropertyValueSet(SpdxConstants.PROP_CROSS_REF, CrossRef.class);
 	}
 
 	/**
@@ -104,6 +113,7 @@ public class SpdxListedLicense extends License {
 		this(builder.name, builder.id, builder.text, builder.sourceUrl, builder.comments, builder.standardLicenseHeader,
 				builder.template, builder.osiApproved, builder.fsfLibre, builder.licenseTextHtml, builder.isDeprecated,
 				builder.deprecatedVersion);
+		this.crossRef.addAll(builder.crossRefs);
 	}
 
 	@Override 
@@ -206,6 +216,10 @@ public class SpdxListedLicense extends License {
 		setPropertyValue(SpdxConstants.PROP_LIC_DEPRECATED_VERSION, deprecatedVersion);
 	}
 
+	public Collection<CrossRef> getCrossRef() throws InvalidSPDXAnalysisException {
+		return this.crossRef;
+	}
+	
 	@Override
 	public String getType() {
 		return SpdxConstants.CLASS_SPDX_LISTED_LICENSE;
@@ -251,6 +265,7 @@ public class SpdxListedLicense extends License {
 		private String licenseTextHtml;
 		private boolean isDeprecated;
 		private String deprecatedVersion;
+		private List<CrossRef> crossRefs = new ArrayList<CrossRef>();
 
 		/**
 		 * @param name License name
@@ -344,6 +359,10 @@ public class SpdxListedLicense extends License {
 			this.deprecatedVersion = deprecatedVersion;
 			return this;
 		}
+		
+		public Builder addCrossRefs(CrossRef crossRef) {
+;			this.crossRefs.add(crossRef);
+			return this;
+		}
 	}
-
 }

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
@@ -229,7 +229,7 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 				}
 				this.licenseIds.put(id.toLowerCase(), id);
 				this.listedLicenseCache.put(id, new LicenseJson(id));
-			} else if (SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION.equals(type)) {
+			} else if (SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION.equals(type)) {
 				if (this.licenseIds.containsKey(id.toLowerCase()) || this.exceptionIds.containsKey(id.toLowerCase())) {
 					logger.error("Duplicate SPDX ID on create: "+id);;
 					throw new DuplicateSpdxIdException("ID "+id+" already exists.");
@@ -838,7 +838,7 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			if (licenseIds.containsKey(id.toLowerCase())) {
 				return Optional.of(new TypedValue(id, SpdxConstants.CLASS_SPDX_LISTED_LICENSE));
 			} else if (exceptionIds.containsKey(id.toLowerCase())) {
-				return Optional.of(new TypedValue(id, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION));
+				return Optional.of(new TypedValue(id, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION));
 			} else if (crossRefs.containsKey(id)) {
 				return Optional.of(new TypedValue(id, SpdxConstants.CLASS_CROSS_REF));
 			} else {
@@ -903,9 +903,9 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 					allItems.add(new TypedValue(licenseId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE));
 				}
 			}
-			if (Objects.isNull(typeFilter) || SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION.equals(typeFilter)) {
+			if (Objects.isNull(typeFilter) || SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION.equals(typeFilter)) {
 				for (String exceptionId:this.exceptionIds.values()) {
-					allItems.add(new TypedValue(exceptionId, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION));
+					allItems.add(new TypedValue(exceptionId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION));
 				}
 			}
 			if (Objects.isNull(typeFilter) || SpdxConstants.CLASS_CROSS_REF.equals(typeFilter)) {

--- a/src/test/java/org/spdx/library/model/license/LicenseExpressionParserTest.java
+++ b/src/test/java/org/spdx/library/model/license/LicenseExpressionParserTest.java
@@ -69,9 +69,9 @@ public class LicenseExpressionParserTest extends TestCase {
 					STD_IDS[i], STD_TEXTS[i], new ArrayList<String>(Arrays.asList(new String[] {"URL "+String.valueOf(i)})), "Notes "+String.valueOf(i),
 					"LicHeader "+String.valueOf(i), "Template "+String.valueOf(i), true, false, "", false, "");
 		}
-		LICENSE_EXCEPTIONS = new LicenseException[EXCEPTION_IDS.length];
+		LICENSE_EXCEPTIONS = new ListedLicenseException[EXCEPTION_IDS.length];
 		for (int i = 0; i < EXCEPTION_IDS.length; i++) {
-			LICENSE_EXCEPTIONS[i] = new LicenseException(EXCEPTION_IDS[i], EXCEPTION_NAMES[i], EXCEPTION_TEXTS[i]);
+			LICENSE_EXCEPTIONS[i] = new ListedLicenseException(EXCEPTION_IDS[i], EXCEPTION_NAMES[i], EXCEPTION_TEXTS[i]);
 		}
 		
 		SpdxDocument doc = new SpdxDocument(modelStore, TEST_DOCUMENT_URI, null, true);

--- a/src/test/java/org/spdx/storage/listedlicense/SpdxListedLicenseLocalStoreTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/SpdxListedLicenseLocalStoreTest.java
@@ -29,6 +29,7 @@ import org.spdx.library.model.SpdxModelFactory;
 import org.spdx.library.model.TypedValue;
 import org.spdx.library.model.license.CrossRef;
 import org.spdx.library.model.license.LicenseException;
+import org.spdx.library.model.license.ListedLicenseException;
 import org.spdx.library.model.license.SpdxListedLicense;
 import org.spdx.licenseTemplate.InvalidLicenseTemplateException;
 import org.spdx.storage.IModelStore;
@@ -91,7 +92,7 @@ public class SpdxListedLicenseLocalStoreTest extends TestCase {
 		assertEquals(nextId, result);
 		
 		nextId = slll.getNextId(IdType.ListedLicense, LICENSE_LIST_URI);
-		slll.create(LICENSE_LIST_URI, nextId, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION);
+		slll.create(LICENSE_LIST_URI, nextId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION);
 		result = (String)slll.getValue(LICENSE_LIST_URI, nextId, SpdxConstants.PROP_LICENSE_EXCEPTION_ID).get();
 		assertEquals(nextId, result);
 		slll.close();
@@ -192,7 +193,7 @@ public class SpdxListedLicenseLocalStoreTest extends TestCase {
 	
 	public void testCreateException() throws InvalidSPDXAnalysisException, InvalidLicenseTemplateException {
 		SpdxListedLicenseLocalStore slll = new SpdxListedLicenseLocalStore();
-		LicenseException result = (LicenseException)SpdxModelFactory.createModelObject(slll, LICENSE_LIST_URI, ECOS_EXCEPTION_ID, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, null);
+		LicenseException result = (LicenseException)SpdxModelFactory.createModelObject(slll, LICENSE_LIST_URI, ECOS_EXCEPTION_ID, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, null);
 		assertEquals(ECOS_EXCEPTION_ID, result.getLicenseExceptionId());
 		assertEquals(ECOS_EXCEPTION_ID, result.getId());
 		assertTrue(result.getComment().length() > 5);
@@ -202,7 +203,7 @@ public class SpdxListedLicenseLocalStoreTest extends TestCase {
 		List<String> lResult = new ArrayList<String>(result.getSeeAlso());
 		assertTrue(lResult.size() > 0);
 		assertTrue(lResult.get(0).length() > 10);
-		assertEquals(SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, (result.getType()));
+		assertEquals(SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, (result.getType()));
 		assertFalse(result.isDeprecated());
 	}
 	
@@ -210,7 +211,7 @@ public class SpdxListedLicenseLocalStoreTest extends TestCase {
 	public void testList() throws InvalidSPDXAnalysisException {
 		SpdxListedLicenseLocalStore slll = new SpdxListedLicenseLocalStore();
 		// Exception
-		LicenseException exception = (LicenseException)SpdxModelFactory.createModelObject(slll, LICENSE_LIST_URI, ECOS_EXCEPTION_ID, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, null);
+		ListedLicenseException exception = (ListedLicenseException)SpdxModelFactory.createModelObject(slll, LICENSE_LIST_URI, ECOS_EXCEPTION_ID, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, null);
 		String seeAlso1 = "seeAlso1";
 		String seeAlso2 = "seeAlso2";
 		List<String> seeAlsos = Arrays.asList(new String[]{seeAlso1, seeAlso2});
@@ -371,7 +372,7 @@ public class SpdxListedLicenseLocalStoreTest extends TestCase {
 		assertFalse(slll.exists(LICENSE_LIST_URI, nextId));
 		
 		nextId = slll.getNextId(IdType.ListedLicense, LICENSE_LIST_URI);
-		slll.create(LICENSE_LIST_URI, nextId, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION);
+		slll.create(LICENSE_LIST_URI, nextId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION);
 		result = (String)slll.getValue(LICENSE_LIST_URI, nextId, SpdxConstants.PROP_LICENSE_EXCEPTION_ID).get();
 		assertEquals(nextId, result);
 		assertTrue(slll.exists(LICENSE_LIST_URI, nextId));

--- a/src/test/java/org/spdx/storage/listedlicense/SpdxListedLicenseWebStoreTest.java
+++ b/src/test/java/org/spdx/storage/listedlicense/SpdxListedLicenseWebStoreTest.java
@@ -29,6 +29,7 @@ import org.spdx.library.model.SpdxModelFactory;
 import org.spdx.library.model.TypedValue;
 import org.spdx.library.model.license.CrossRef;
 import org.spdx.library.model.license.LicenseException;
+import org.spdx.library.model.license.ListedLicenseException;
 import org.spdx.library.model.license.SpdxListedLicense;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
@@ -90,7 +91,7 @@ public class SpdxListedLicenseWebStoreTest extends TestCase {
 		assertEquals(nextId, result);
 
 		nextId = sllw.getNextId(IdType.ListedLicense, LICENSE_LIST_URI);
-		sllw.create(LICENSE_LIST_URI, nextId, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION);
+		sllw.create(LICENSE_LIST_URI, nextId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION);
 		result = (String)sllw.getValue(LICENSE_LIST_URI, nextId, SpdxConstants.PROP_LICENSE_EXCEPTION_ID).get();
 		assertEquals(nextId, result);
 		sllw.close();
@@ -217,7 +218,7 @@ public class SpdxListedLicenseWebStoreTest extends TestCase {
 	@SuppressWarnings("deprecation")
 	public void testCreateException() throws Exception {
 		SpdxListedLicenseWebStore sllw = new SpdxListedLicenseWebStore();
-		LicenseException result = (LicenseException)SpdxModelFactory.createModelObject(sllw, LICENSE_LIST_URI, ECOS_EXCEPTION_ID, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, null);
+		LicenseException result = (LicenseException)SpdxModelFactory.createModelObject(sllw, LICENSE_LIST_URI, ECOS_EXCEPTION_ID, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, null);
 		assertEquals(ECOS_EXCEPTION_ID, result.getLicenseExceptionId());
 		assertEquals(ECOS_EXCEPTION_ID, result.getId());
 		assertTrue(result.getComment().length() > 5);
@@ -230,7 +231,7 @@ public class SpdxListedLicenseWebStoreTest extends TestCase {
 		List<String> lResult = new ArrayList<String>(result.getSeeAlso());
 		assertTrue(lResult.size() > 0);
 		assertTrue(lResult.get(0).length() > 10);
-		assertEquals(SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, (result.getType()));
+		assertEquals(SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, (result.getType()));
 		assertFalse(result.isDeprecated());
 	}
 	
@@ -238,7 +239,7 @@ public class SpdxListedLicenseWebStoreTest extends TestCase {
 	public void testList() throws Exception {
 		SpdxListedLicenseWebStore sllw = new SpdxListedLicenseWebStore();
 		// Exception
-		LicenseException exception = (LicenseException)SpdxModelFactory.createModelObject(sllw, LICENSE_LIST_URI, ECOS_EXCEPTION_ID, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION, null);
+		ListedLicenseException exception = (ListedLicenseException)SpdxModelFactory.createModelObject(sllw, LICENSE_LIST_URI, ECOS_EXCEPTION_ID, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, null);
 		String seeAlso1 = "seeAlso1";
 		String seeAlso2 = "seeAlso2";
 		List<String> seeAlsos = Arrays.asList(new String[]{seeAlso1, seeAlso2});
@@ -381,7 +382,7 @@ public class SpdxListedLicenseWebStoreTest extends TestCase {
 		assertFalse(sllw.exists(LICENSE_LIST_URI, nextId));
 		
 		nextId = sllw.getNextId(IdType.ListedLicense, LICENSE_LIST_URI);
-		sllw.create(LICENSE_LIST_URI, nextId, SpdxConstants.CLASS_SPDX_LICENSE_EXCEPTION);
+		sllw.create(LICENSE_LIST_URI, nextId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION);
 		result = (String)sllw.getValue(LICENSE_LIST_URI, nextId, SpdxConstants.PROP_LICENSE_EXCEPTION_ID).get();
 		assertEquals(nextId, result);
 		assertTrue(sllw.exists(LICENSE_LIST_URI, nextId));


### PR DESCRIPTION
Fixes #139 

This PR also changes all references to `LicenseException` to `ListedLicenseException` to allow for not copying the exception details.  Note that this change to ListedExceptions is also required for any enhancement allowing locally created exceptions.