### PR TITLE
Issue 149: Add auto-generation and publication of API JavaDocs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,21 +15,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 11
     - name: Cache SonarCloud packages
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Cache Maven packages
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: 11
     - name: Cache SonarCloud packages
       uses: actions/cache@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Generate and publish API JavaDocs
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+
+      - name: Generate docs
+        run: mvn javadoc:javadoc
+
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/site/apidocs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,23 +9,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 11
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: 11
+    - name: Cache Maven packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
 
-      - name: Generate docs
-        run: mvn javadoc:javadoc
+    - name: Generate docs
+      run: mvn javadoc:javadoc
 
-      - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/site/apidocs
+    - name: Deploy docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/site/apidocs

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ If you are using Maven, you can add the following dependency in your POM file:
 </dependency>
 ```
 
+[API JavaDocs are available here.](https://spdx.github.io/Spdx-Java-Library/)
+
 There are a couple of static classes that help common usage scenarios:
 
 - org.spdx.library.SPDXModelFactory supports the creation of specific model objects


### PR DESCRIPTION
This PR addresses issue #149, by adding automatic generation and publication of API JavaDocs upon push of a PR to the `master` branch (note: there may be a better condition to ensure this job only fires when a new version of the library is released / published - I'm not familiar enough with the project's branching / tagging approach to have set that up in this PR).

This PR is necessary but not sufficient to enable API JavaDoc generation and publication - it will also require some [configuration of the GitHub project itself](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) by a project owner. Note that in the past I've noticed a one-time "chicken and egg" problem with these setup steps:
* the project configuration changes can't be made until the action has run at least once (in order to create the `gh-pages` branch that needs to be referenced in that configuration)
* the action fails the first time because the project isn't configured for GitHub pages yet

This is a minor one-time annoyance, but I thought it worth noting as I've been bitten by it in the past and thought something had gone wrong.