### PR TITLE
verifyDownloadLocation error message clarification

### DIFF
--- a/src/main/java/org/spdx/library/SpdxVerificationHelper.java
+++ b/src/main/java/org/spdx/library/SpdxVerificationHelper.java
@@ -289,7 +289,7 @@ public class SpdxVerificationHelper {
 		} else if (SpdxConstants.DOWNLOAD_LOCATION_PATTERN.matcher(downloadLocation).matches()) {
 			return null;
 		} else {
-			return "Invalid download location pattern "+downloadLocation+".  Must match the pattern "+
+			return "Invalid download location "+downloadLocation+".  Must match the pattern "+
 					SpdxConstants.DOWNLOAD_LOCATION_PATTERN.pattern();
 		}
 	}


### PR DESCRIPTION
This should make it faster for readers to distinguish which string is the configured download location and which string is the required pattern, particularly if these strings are long.