### PR TITLE
Move license matching code which removes underlines

### DIFF
--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -230,7 +230,6 @@ public class LicenseCompareHelper {
 	            	line = line.replaceAll("(\\*/|-->|-\\}|\\*\\))\\s*$", "");  // remove end of line comments
 	                line = line.replaceAll("^\\s*" + START_COMMENT_CHAR_PATTERN, "");  // remove start of line comments
                     line = line.replaceAll("^\\s*<<beginOptional>>\\s*" + START_COMMENT_CHAR_PATTERN, "<<beginOptional>>");
-                    line = line.replaceAll("(-|=|\\*){3,}", "");  // Remove ----, ***,  and ====
                     sb.append(line);
 	                sb.append("\n");
 	                line = reader.readLine();
@@ -940,6 +939,7 @@ public class LicenseCompareHelper {
 		Pattern matchPattern = nonOptionalTextToStartPattern(templateNonOptionalText, CROSS_REF_NUM_WORDS_MATCH);
 		List<Pair<Integer, Integer>> charPositions = new ArrayList<>();
 		String normalizedText = removeCommentChars(normalizeText(text));
+		normalizedText = normalizedText.replaceAll("(-|=|\\*){3,}", "");  // Remove ----, ***,  and ====
 		String compareText;
 		try {
 			compareText = normalizeTokensForRegex(normalizedText, charPositions);

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -718,6 +718,7 @@ public class LicenseCompareHelperTest extends TestCase {
 		SpdxListedLicense gpl30 = ListedLicenses.getListedLicenses().getListedLicenseById("GPL-3.0");
 		SpdxListedLicense apache10 = ListedLicenses.getListedLicenses().getListedLicenseById("Apache-1.0");
 		SpdxListedLicense apache20 = ListedLicenses.getListedLicenses().getListedLicenseById("Apache-2.0");
+		SpdxListedLicense mplLicense = ListedLicenses.getListedLicenses().getListedLicenseById("MPL-2.0");
 		String multiLicenseText = gpl30.getLicenseText() + "\n\n----------\n\n" + apache20.getLicenseText();
 		String textWithRandomPrefixAndSuffix = "Some random preamble text.\n\n" + apache20.getLicenseText() + "\n\nSome random epilogue text.";
 
@@ -730,8 +731,9 @@ public class LicenseCompareHelperTest extends TestCase {
 		assertTrue(LicenseCompareHelper.isStandardLicenseWithinText(textWithRandomPrefixAndSuffix, apache20));
 		assertFalse(LicenseCompareHelper.isStandardLicenseWithinText(multiLicenseText, apache10));
 		String mplText = UnitTestHelper.fileToText(MPL_2_FROM_MOZILLA_FILE);
-		assertTrue(LicenseCompareHelper.isStandardLicenseWithinText(mplText, ListedLicenses.getListedLicenses().getListedLicenseById("MPL-2.0")));
-
+		assertTrue(LicenseCompareHelper.isStandardLicenseWithinText(mplText, mplLicense));
+		DifferenceDescription mplDiff = LicenseCompareHelper.isTextStandardLicense(mplLicense, mplText);
+		assertFalse(mplDiff.isDifferenceFound());
 
 /* Currently doesn't work - see https://github.com/spdx/Spdx-Java-Library/issues/141 for details
 		// JavaMail license is "CDDL-1.1 OR GPL-2.0 WITH Classpath-exception-2.0"


### PR DESCRIPTION
Fixes an issue with matching caused by PR #156