### PR TITLE
correctly integrate slf4j via pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,9 +96,15 @@
     	<version>2.0.7</version>
     </dependency>
     <dependency>
-    	<groupId>org.slf4j</groupId>
-    	<artifactId>slf4j-simple</artifactId>
-    	<version>2.0.7</version>
+    	<groupId>org.apache.logging.log4j</groupId>
+    	<artifactId>log4j-slf4j2-impl</artifactId>
+    	<version>2.20.0</version>
+    	<exclusions>
+    	    <exclusion>
+			    <groupId>org.slf4j</groupId>
+			    <artifactId>slf4j-api</artifactId>
+		    </exclusion>
+		</exclusions>
     </dependency>
     <dependency>
     	<groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-    	<groupId>org.apache.logging.log4j</groupId>
-    	<artifactId>log4j-slf4j18-impl</artifactId>
-    	<version>2.18.0</version>
+    	<groupId>org.slf4j</groupId>
+    	<artifactId>slf4j-api</artifactId>
+    	<version>2.0.7</version>
+    </dependency>
+    <dependency>
+    	<groupId>org.slf4j</groupId>
+    	<artifactId>slf4j-simple</artifactId>
+    	<version>2.0.7</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -101,10 +101,10 @@
     	<version>2.20.0</version>
     	<exclusions>
     	    <exclusion>
-			    <groupId>org.slf4j</groupId>
-			    <artifactId>slf4j-api</artifactId>
-		    </exclusion>
-		</exclusions>
+    	        <groupId>org.slf4j</groupId>
+    	        <artifactId>slf4j-api</artifactId>
+    	    </exclusion>
+    	</exclusions>
     </dependency>
     <dependency>
     	<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Change log4j-slf4j18-impl to the [correct implementation](https://www.slf4j.org/manual.html#projectDep) so that I don't have to actively exclude log4j-slf4j18-impl when integrating Spdx-Java-Library via Maven in the future.