### PR TITLE
move slf4j implementation to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,23 @@
     </properties>
 	<profiles>
 		<profile>
+			<id>test</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j2-impl</artifactId>
+					<version>2.20.0</version>
+					<scope>test</scope>
+					<exclusions>
+						<exclusion>
+							<groupId>org.slf4j</groupId>
+							<artifactId>slf4j-api</artifactId>
+						</exclusion>
+					</exclusions>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
 				<jdk>[1.8,)</jdk>
@@ -97,17 +114,6 @@
     	<groupId>org.slf4j</groupId>
     	<artifactId>slf4j-api</artifactId>
     	<version>2.0.7</version>
-    </dependency>
-    <dependency>
-    	<groupId>org.apache.logging.log4j</groupId>
-    	<artifactId>log4j-slf4j2-impl</artifactId>
-    	<version>2.20.0</version>
-    	<exclusions>
-    	    <exclusion>
-    	        <groupId>org.slf4j</groupId>
-    	        <artifactId>slf4j-api</artifactId>
-    	    </exclusion>
-    	</exclusions>
     </dependency>
     <dependency>
     	<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
>sorry, I saw this too late: the library should not force ANY implementation 
it's up to the library user to choose what logging implementation he uses:

> - Maven uses something 
> - someone else in another runtime context will choose another implementation 

>in the context of the library, perhaps setting an implementation with a test scope can make sense

After this discussion in my last PR #185 here is the requested change.