### PR TITLE
Add Automatic-Module-Name entry to jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,13 @@
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-jar-plugin</artifactId>
 	      <version>3.3.0</version>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>org.spdx.library</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
 		</plugin>
 	   	<plugin>
 	      <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR adds a the `Automatic-Module-Name` manifest entry, making it easier for modular projects (Java 9 and above) to include this library. I've given the name `org.spdx.library` to the module, this can of course be changed if desired.
