### PR TITLE
Redesign the match within text

### DIFF
--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -1,6 +1,7 @@
 # Release Checklist for the SPDX Java Tools
 
 - [ ] Check for any warnings from the compiler and findbugs
+- [ ] Run unit tests for all packages that depend on the library
 - [ ] Run dependency check to find any potential vulnerabilities `mvn dependency-check:check`
 - [ ] Test the release `mvn release:prepare -DdryRun`
 - [ ] Run `mvn release:prepare` - you will be prompted for the release - typically take the defaults

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -2,6 +2,7 @@
 
 - [ ] Check for any warnings from the compiler and findbugs
 - [ ] Run unit tests for all packages that depend on the library
+- [ ] Run unit tests with `export SPDX_JAVA_LIB_RUN_SLOW_TESTS=true` to ensure the extended (slow) test suite passes
 - [ ] Run dependency check to find any potential vulnerabilities `mvn dependency-check:check`
 - [ ] Test the release `mvn release:prepare -DdryRun`
 - [ ] Run `mvn release:prepare` - you will be prompted for the release - typically take the defaults

--- a/TestFiles/ImageMagick.template.txt
+++ b/TestFiles/ImageMagick.template.txt
@@ -1,0 +1,115 @@
+<<beginOptional>>Before we get to the text of the license, lets just review what the license says in simple terms:
+
+It allows you to:
+
+   <<var;name="bullet";original="*";match=".{0,20}">> freely download and use ImageMagick software, in whole or in part, for personal, company internal, or commercial purposes;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> use ImageMagick software in packages or distributions that you create;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> link against a library under a different license;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> link code under a different license against a library under this license;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> merge code into a work under a different license;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> extend patent grants to any code using code under this license;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> and extend patent protection.
+
+It forbids you to:
+
+   <<var;name="bullet";original="*";match=".{0,20}">> redistribute any piece of ImageMagick-originated software without proper attribution;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> use any marks owned by ImageMagick Studio LLC in any way that might state or imply that ImageMagick Studio LLC endorses your distribution;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> use any marks owned by ImageMagick Studio LLC in any way that might state or imply that you created the ImageMagick software in question.
+
+It requires you to:
+
+   <<var;name="bullet";original="*";match=".{0,20}">> include a copy of the license in any redistribution you may make that includes ImageMagick software;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> provide clear attribution to ImageMagick Studio LLC for any distributions that include ImageMagick software.
+
+It does not require you to:
+
+   <<var;name="bullet";original="*";match=".{0,20}">> include the source of the ImageMagick software itself, or of any modifications you may have made to it, in any redistribution you may assemble that includes it;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> submit changes that you make to the software back to the ImageMagick Studio LLC (though such feedback is encouraged).
+
+A few other clarifications include:
+
+   <<var;name="bullet";original="*";match=".{0,20}">> ImageMagick is freely available without charge;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> you may include ImageMagick on a DVD as long as you comply with the terms of the license;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> you can give modified code away for free or sell it under the terms of the ImageMagick license or distribute the result under a different license, but you need to acknowledge the use of the ImageMagick software;
+
+   <<var;name="bullet";original="*";match=".{0,20}">> the license is compatible with the GPL V3.
+
+   <<var;name="bullet";original="*";match=".{0,20}">> when exporting the ImageMagick software, review its export classification.<<endOptional>>
+
+Terms and Conditions for Use, Reproduction, and Distribution
+
+The legally binding and authoritative terms and conditions for use, reproduction, and distribution of ImageMagick follow:
+
+<<var;name="copyright";original="Copyright 1999-2013 ImageMagick Studio LLC, a non-profit organization dedicated to making software imaging solutions freely available.  ";match=".{0,5000}">>
+
+   <<var;name="bullet";original="1.";match=".{0,20}">> Definitions.
+
+   License shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+   Licensor shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+   Legal Entity shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, control means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+   You (or Your) shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+   Source form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+   Object form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+   Work shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+   Derivative Works shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+   Contribution shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as Not a Contribution.
+
+   Contributor shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+   <<var;name="bullet";original="2.";match=".{0,20}">> Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+   <<var;name="bullet";original="3.";match=".{0,20}">> Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+   <<var;name="bullet";original="4.";match=".{0,20}">> Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+      <<var;name="bullet";original="a.";match=".{0,20}">> You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+      <<var;name="bullet";original="b.";match=".{0,20}">> You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+      <<var;name="bullet";original="c.";match=".{0,20}">> You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+      <<var;name="bullet";original="d.";match=".{0,20}">> If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+   <<var;name="bullet";original="5.";match=".{0,20}">> Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+   <<var;name="bullet";original="6.";match=".{0,20}">> Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+   <<var;name="bullet";original="7.";match=".{0,20}">> Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+   <<var;name="bullet";original="8.";match=".{0,20}">> Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+   <<var;name="bullet";original="9.";match=".{0,20}">> Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.<<beginOptional>> How to Apply the License to your Work
+
+To apply the ImageMagick License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information (don't include the brackets). The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the ImageMagick License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.imagemagick.org/script/license.php
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+<<endOptional>>

--- a/src/main/java/org/spdx/utility/compare/FilterTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/utility/compare/FilterTemplateOutputHandler.java
@@ -26,10 +26,13 @@ import org.spdx.licenseTemplate.ILicenseTemplateOutputHandler;
 import org.spdx.licenseTemplate.LicenseTemplateRule;
 
 /**
+ * @deprecated The <code>TemplateRegexMatcher</code> class should be used in place of this class.  This class will be removed in the next major release.
+ * 
  * Filter the template output to create a list of strings filtering out optional and/or var text
  * @author Gary O'Neall
  *
  */
+@Deprecated
 public class FilterTemplateOutputHandler implements ILicenseTemplateOutputHandler {
 	
 	public static final String REGEX_ESCAPE = "~~~";

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -60,6 +60,7 @@ import org.spdx.utility.compare.FilterTemplateOutputHandler.VarTextHandling;
  * @author Gary O'Neall
  *
  */
+@SuppressWarnings("deprecation")
 public class LicenseCompareHelper {
 	
 	static final Logger logger = LoggerFactory.getLogger(LicenseCompareHelper.class);
@@ -638,6 +639,7 @@ public class LicenseCompareHelper {
 	}
 	
 	/**
+	 * @deprecated The <code>TemplateRegexMatcher</code> class should be used in place of this method. This method will be removed in the next major release.
 	 * Get the text of a license minus any optional text - note: this include the default variable text
 	 * @param licenseTemplate license template containing optional and var tags
 	 * @param includeVarText if true, include the default variable text; if false remove the variable text
@@ -685,6 +687,7 @@ public class LicenseCompareHelper {
 	}
 	
 	/**
+	 * @deprecated The <code>TemplateRegexMatcher</code> class should be used in place of this method. This method will be removed in the next major release.
 	 * Creates a regular expression pattern to match the start of a license text
 	 * This method should be replaced by the <code>TemplateRegexMatcher</code> class and methods
 	 * @param nonOptionalText List of strings of non-optional text from the license template (see {@literal List<String> getNonOptionalLicenseText})

--- a/src/main/java/org/spdx/utility/compare/TemplateRegexGenerator.java
+++ b/src/main/java/org/spdx/utility/compare/TemplateRegexGenerator.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2023 Source Auditor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.spdx.utility.compare;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spdx.licenseTemplate.ILicenseTemplateOutputHandler;
+import org.spdx.licenseTemplate.LicenseParserException;
+import org.spdx.licenseTemplate.LicenseTemplateRule;
+import org.spdx.licenseTemplate.LicenseTemplateRuleException;
+import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
+
+/**
+ * Generates a regular expression from a license or exception template
+ * 
+ * Note that the regular expression assumes a fully normalized text string to match
+ * 
+ * <code>findTemplateWithinText(String text)</code> will return text matching the template based on the generated start and end regexes
+ * 
+ * <code>getCompleteRegex()</code> will return a regular expression for the entire license where
+ * <code>getStartRegex(int wordLimit)</code> will return a regular expression to match the beginning of a license
+ * and <code>getEndRegex(int wordLimit)</code> will return a regular expression to match the end of a license
+ * 
+ * @author Gary O'Neall
+ *
+ */
+public class TemplateRegexGenerator implements ILicenseTemplateOutputHandler {
+	
+	static final Logger logger = LoggerFactory.getLogger(TemplateRegexGenerator.class);
+	
+	static final int WORD_LIMIT = 25; // number of words to search for at the beginning and end of the template
+	
+	static abstract class RegexElement {
+	}
+	
+	static class RegexList extends RegexElement {
+		private List<RegexElement> elements = new ArrayList<>();
+		
+		public void addElement(RegexElement element) {
+			elements.add(element);
+		}
+		
+		public List<RegexElement> getElements() {
+			return elements;
+		}
+		
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			for (RegexElement element:elements) {
+				sb.append(element.toString());
+			}
+			return sb.toString();
+		}
+	}
+	
+	/**
+	 * Group with the optional modifier
+	 */
+	static class OptionalRegexGroup extends RegexList {
+		
+		@Override
+		public String toString() {
+			return "(" + super.toString() + ")?";
+		}
+	}
+	
+	static class RegexToken extends RegexElement {
+		private String token;
+		
+		public RegexToken(String token) {
+			this.token = token.trim();
+		}
+		
+		public String getToken() {
+			return token;
+		}
+		
+		@Override
+		public String toString() {
+			return Pattern.quote(
+					LicenseCompareHelper.NORMALIZE_TOKENS.getOrDefault(token.toLowerCase(), token)) + 
+					"\\s*";
+		}
+	}
+	
+	static class RegexPattern extends RegexElement {
+		private String pattern;
+		
+		public RegexPattern(String pattern) {
+			this.pattern = pattern;
+		}
+		
+		public String getPattern() {
+			return pattern;
+		}
+		
+		@Override
+		public String toString() {
+			return "(" + pattern + ")"; // We always treat the pattern as a group
+		}
+
+		/**
+		 * @param pattern pattern to set
+		 */
+		public void setPattern(String pattern) {
+			this.pattern = pattern;
+		}
+	}
+
+	private String template;
+	
+	/**
+	 * Top level regex
+	 */
+	private RegexList regexPatternList = new RegexList();
+	
+	
+	private int optionalNestLevel = 0;
+	
+	private List<OptionalRegexGroup> optionalGroups = new ArrayList<>();
+
+	/**
+	 * Generates regular expressions from a license or exception template
+	 * @throws SpdxCompareException 
+	 */
+	public TemplateRegexGenerator(String template) throws SpdxCompareException {
+		this.template = template;
+		parseTemplate();
+	}
+	
+	/**
+	 * Parses the template generating the regular expression
+	 * @throws SpdxCompareException 
+	 */
+	private void parseTemplate() throws SpdxCompareException {
+		try {
+			SpdxLicenseTemplateHelper.parseTemplate(LicenseCompareHelper.removeCommentChars(template), this);
+		} catch (LicenseTemplateRuleException e) {
+			throw new SpdxCompareException("Invalid template rule found during filter: "+e.getMessage(),e);
+		} catch (LicenseParserException e) {
+			throw new SpdxCompareException("Invalid template found during filter: "+e.getMessage(),e);
+		}
+	}
+	
+	/**
+	 * @return the complete regular expression for the template
+	 */
+	public String getCompleteRegex() {
+		return regexPatternList.toString();
+	}
+	
+	/**
+	 * @param wordLimit number of non optional words to include in the pattern
+	 * @return a regex to match the start of the license per the template
+	 */
+	public String getStartRegex(int wordLimit) {
+		RegexList result = new RegexList();
+		int index = 0;
+		int numWords = 0;
+		List<RegexElement> elementList = regexPatternList.getElements();
+		while (index < elementList.size() && numWords <= wordLimit) {
+			RegexElement element = elementList.get(index++);
+			result.addElement(element);
+			if (element instanceof RegexToken) {
+				numWords++;
+			}
+		}
+		// Need to check if the string starts with a greedy regex and change to non-greedy
+		if (result.getElements().size() > 0) {
+			RegexElement firstElement = result.getElements().get(0);
+			if (firstElement instanceof RegexPattern) {
+				String pattern = ((RegexPattern)firstElement).pattern;
+				if (!pattern.startsWith(".?") && pattern.startsWith(".")) {
+					((RegexPattern)firstElement).setPattern(".?" + pattern.substring(1));
+				}
+			}
+		}
+		return result.toString();
+	}
+	
+	/**
+	 * @param wordLimit number of non optional words to include in the pattern
+	 * @return a regex to match the end of the license per the template
+	 */
+	public String getEndRegex(int wordLimit) {
+		RegexList result = new RegexList();
+		int numWords = 0;
+		List<RegexElement> elementList = regexPatternList.getElements();
+		int index = elementList.size()-1;
+		// find the beginning of the end ...
+		while (index > 0 && numWords <= wordLimit) {
+			if (elementList.get(index--) instanceof RegexToken) {
+				numWords++;
+			}
+		}
+		while (index < elementList.size()) {
+			result.addElement(elementList.get(index++));
+		}
+		return result.toString();
+	}
+
+	/**
+	 * @param text
+	 * @return the text matching the beginning and end regular expressions for the template.  Null if there is no match.
+	 * @throws SpdxCompareException
+	 */
+	public @Nullable String findTemplateWithinText(String text) throws SpdxCompareException {
+		// Get match status
+		String result = null;
+		int startIndex = -1;
+		int endIndex = -1;
+
+		if (text == null || text.isEmpty() || template == null) {
+			return null;
+		}
+		
+		StringBuilder normalizedText = new StringBuilder();
+		
+		for (String token:LicenseCompareHelper.tokenizeLicenseText(text, new HashMap<>())) {
+			normalizedText.append(
+					LicenseCompareHelper.NORMALIZE_TOKENS.getOrDefault(token.toLowerCase(), token.toLowerCase()));
+			normalizedText.append(' ');
+		}
+		
+		String compareText = normalizedText.toString();
+
+		Pattern startPattern = Pattern.compile(getStartRegex(WORD_LIMIT), Pattern.DOTALL|Pattern.CASE_INSENSITIVE);
+		Matcher startMatcher = startPattern.matcher(compareText);
+		if(startMatcher.find()) {
+			startIndex = startMatcher.start();
+			Pattern endPattern = Pattern.compile(getEndRegex(WORD_LIMIT), Pattern.DOTALL|Pattern.CASE_INSENSITIVE);
+			Matcher endMatcher = endPattern.matcher(compareText);
+			if (endMatcher.find()) {
+				endIndex = endMatcher.end();
+				result = compareText.substring(startIndex, endIndex);
+			}
+		}
+		return result;
+	}
+	
+	private RegexList getCurrentList() {
+		return optionalNestLevel == 0 ? regexPatternList : optionalGroups.get(optionalNestLevel - 1);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.spdx.licenseTemplate.ILicenseTemplateOutputHandler#text(java.lang.String)
+	 */
+	@Override
+	public void text(String text) {
+		RegexList currentList = getCurrentList();
+		for (String token:LicenseCompareHelper.tokenizeLicenseText(text, new HashMap<>())) {
+			currentList.addElement(new RegexToken(
+					LicenseCompareHelper.NORMALIZE_TOKENS.getOrDefault(token.toLowerCase(), token.toLowerCase())));
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see org.spdx.licenseTemplate.ILicenseTemplateOutputHandler#variableRule(org.spdx.licenseTemplate.LicenseTemplateRule)
+	 */
+	@Override
+	public void variableRule(LicenseTemplateRule rule) {
+		getCurrentList().addElement(new RegexPattern(rule.getMatch()));
+	}
+
+	/* (non-Javadoc)
+	 * @see org.spdx.licenseTemplate.ILicenseTemplateOutputHandler#beginOptional(org.spdx.licenseTemplate.LicenseTemplateRule)
+	 */
+	@Override
+	public void beginOptional(LicenseTemplateRule rule) {
+		optionalNestLevel++;
+		if (optionalGroups.size() == optionalNestLevel) {
+			logger.warn("Optional groups size does not match the nest level");
+			optionalGroups.set(optionalNestLevel-1, new OptionalRegexGroup());
+		} else {
+			optionalGroups.add(new OptionalRegexGroup());
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see org.spdx.licenseTemplate.ILicenseTemplateOutputHandler#endOptional(org.spdx.licenseTemplate.LicenseTemplateRule)
+	 */
+	@Override
+	public void endOptional(LicenseTemplateRule rule) {
+		OptionalRegexGroup optionalGroup = optionalGroups.get(optionalNestLevel - 1);
+		optionalGroups.remove(optionalNestLevel - 1);
+		optionalNestLevel--;
+		getCurrentList().addElement(optionalGroup);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.spdx.licenseTemplate.ILicenseTemplateOutputHandler#completeParsing()
+	 */
+	@Override
+	public void completeParsing() throws LicenseParserException {
+		// Nothing to do here
+	}
+
+}

--- a/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
+++ b/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
@@ -57,10 +57,10 @@ public class TemplateRegexMatcher implements ILicenseTemplateOutputHandler {
 	
 	static final String REGEX_GLOBAL_MODIFIERS = "(?im)"; // ignore case and muti-line
 	
-	static abstract class RegexElement {
+	interface RegexElement {
 	}
 	
-	static class RegexList extends RegexElement {
+	static class RegexList implements RegexElement {
 		private List<RegexElement> elements = new ArrayList<>();
 		
 		public void addElement(RegexElement element) {
@@ -92,7 +92,7 @@ public class TemplateRegexMatcher implements ILicenseTemplateOutputHandler {
 		}
 	}
 	
-	static class RegexToken extends RegexElement {
+	static class RegexToken implements RegexElement {
 		private String token;
 		
 		public RegexToken(String token) {
@@ -111,7 +111,7 @@ public class TemplateRegexMatcher implements ILicenseTemplateOutputHandler {
 		}
 	}
 	
-	static class RegexPattern extends RegexElement {
+	static class RegexPattern implements RegexElement {
 		private String pattern;
 		
 		public RegexPattern(String pattern) {
@@ -194,7 +194,7 @@ public class TemplateRegexMatcher implements ILicenseTemplateOutputHandler {
 			}
 		}
 		// Need to check if the string starts with a greedy regex and change to non-greedy
-		if (result.getElements().size() > 0) {
+		if (!result.getElements().isEmpty()) {
 			RegexElement firstElement = result.getElements().get(0);
 			if (firstElement instanceof RegexPattern) {
 				String pattern = ((RegexPattern)firstElement).pattern;
@@ -248,7 +248,7 @@ public class TemplateRegexMatcher implements ILicenseTemplateOutputHandler {
 	 * @return the text matching the beginning and end regular expressions for the template.  Null if there is no match.
 	 * @throws SpdxCompareException
 	 */
-	private @Nullable String findTemplateWithinText(String text) throws SpdxCompareException {
+	private @Nullable String findTemplateWithinText(String text) {
 		// Get match status
 		String result = null;
 		int startIndex = -1;

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -91,6 +91,7 @@ public class LicenseCompareHelperTest extends TestCase {
     static final String EPL_2_TEMPLATE = "TestFiles" + File.separator + "EPL-2.0.template.txt";
     static final String GPL_2_NL = "TestFiles" + File.separator + "GPL-2.0-NL.txt";
     static final String GPL_2_TEMPLATE = "TestFiles" + File.separator + "GPL-2.0-only.template.txt";
+    static final String IMAGE_MAGIK_TEMPLATE = "TestFiles" + File.separator + "ImageMagick.template.txt";
 
 	/**
 	 * @throws java.lang.Exception
@@ -1069,6 +1070,15 @@ public class LicenseCompareHelperTest extends TestCase {
         	fail(diff.getDifferenceMessage());
         }
         assertTrue(LicenseCompareHelper.isStandardLicenseWithinText(licText, lic));
+    }
+    
+    public void testImageMagikTextWithin() throws InvalidSPDXAnalysisException, SpdxCompareException, IOException {
+        String licText = UnitTestHelper.fileToText(MPL_2_FROM_MOZILLA_FILE);
+        String templateText = UnitTestHelper.fileToText(IMAGE_MAGIK_TEMPLATE);
+        SpdxListedLicense lic = new SpdxListedLicense(
+                new SpdxListedLicense.Builder("imageMagik", "imageMagik", licText)
+                .setTemplate(templateText));
+        assertFalse(LicenseCompareHelper.isStandardLicenseWithinText(licText, lic));
     }
     
 }


### PR DESCRIPTION
This is currently a work in progress redesign of the match license / expression within text.

It creates a new class `TemplexRegexGenerator` which replaces much of the static methods and optional filtering class of the previous implementation.

There is currently one unit test failing, so it is not quite ready to merge.