### PR TITLE
Support file path (file:/) for download location regex

### DIFF
--- a/src/main/java/org/spdx/library/SpdxConstants.java
+++ b/src/main/java/org/spdx/library/SpdxConstants.java
@@ -366,7 +366,7 @@ public class SpdxConstants {
 	
 	// Download Location Format
 	private static final String SUPPORTED_DOWNLOAD_REPOS = "(git|hg|svn|bzr)";
-	private static final String URL_PATTERN = "(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/|ssh:\\/\\/|git:\\/\\/|svn:\\/\\/|sftp:\\/\\/|ftp:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+){0,100}\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?";
+    private static final String URL_PATTERN = "(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/|ssh:\\/\\/|git:\\/\\/|svn:\\/\\/|sftp:\\/\\/|ftp:\\/\\/|file:\\/\\/|file:\\/)?[a-zA-Z0-9\\.\\-\\ \\_]+(:[0-9]{1,5})?(\\/.*)?";
 	private static final String GIT_PATTERN = "(git\\+git@[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9/\\\\.@\\-]+)";
 	private static final String BAZAAR_PATTERN = "(bzr\\+lp:[a-zA-Z0-9\\.\\-]+)";
 	public static final Pattern DOWNLOAD_LOCATION_PATTERN = Pattern.compile("^(NONE|NOASSERTION|(("+SUPPORTED_DOWNLOAD_REPOS+"\\+)?"+URL_PATTERN+")|"+GIT_PATTERN+"|"+BAZAAR_PATTERN+")$", Pattern.CASE_INSENSITIVE);

--- a/src/test/java/org/spdx/library/SpdxVerificationHelperTest.java
+++ b/src/test/java/org/spdx/library/SpdxVerificationHelperTest.java
@@ -156,6 +156,12 @@ public class SpdxVerificationHelperTest extends TestCase {
 	public void testVerifyDownloadLocation() {
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("NONE")));
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("NOASSERTION")));
+        //file
+        assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("file:/Users/dummy/.m2/repository/jakarta/annotation/jakarta.annotation-api/2.1.1/jakarta.annotation-api-2.1.1.jar")));
+        assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("file://Users/dummy_user/.m2/repository/jakarta/annotation/jakarta.annotation-api/2.1.1/jakarta.annotation-api-2.1.1.jar")));
+        assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("file:/path.123A/dummy_123/.m2/repository/jakarta/annotation/jakarta.annotation-api/2.1.1/jakarta.annotation-api-2.1.1.jar")));
+        assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("file://path_ . -abc/dummy.user/.m2/repository/jakarta/annotation/jakarta.annotation-api/2.1.1/jakarta.annotation-api-2.1.1.jar")));
+
 		// http
 		assertTrue(Objects.isNull(SpdxVerificationHelper.verifyDownloadLocation("http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz")));
 		// git


### PR DESCRIPTION
Support for files as part of download location 

Currently regex defined for location validation doesn't allow for files 
fixed updated the regex to include files 
location example :- file:/Users/javarun/.m2/repository/jakarta/annotation/jakarta.annotation-api/2.1.1/jakarta.annotation-api-2.1.1.jar