### PR TITLE
Add unit tests that exercise issue #234

### DIFF
--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -48,7 +48,7 @@ public class CompareConsistencyHelper {
         Collections.sort(matchingStandardLicenseIds);
         Collections.sort(matchingStandardLicenseIdsWithinText);
 
-        if (isDifferenceFound == isStandardLicenseWithinText) {  // Note: this condition seems backwards, but only because one variable indicates whether there was a difference, while the other indicates whether the license was found (they're logically opposite)
+        if (isDifferenceFound == isStandardLicenseWithinText) {  // Note: this condition may seem backwards, but only because one variable indicates whether there was a difference, while the other indicates whether the license was found (they're logically opposite)
             result.append("  * .isTextStandardLicense() and .isStandardLicenseWithinText()\n");
         }
 
@@ -60,11 +60,11 @@ public class CompareConsistencyHelper {
             result.append("  * .isTextStandardLicense() and .matchingStandardLicensesWithinText()\n");
         }
 
-        if (!isStandardLicenseWithinText && matchingStandardLicenseIds.isEmpty()) {
+        if (isStandardLicenseWithinText && matchingStandardLicenseIds.isEmpty()) {
             result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicenseIds()\n");
         }
 
-        if (!isStandardLicenseWithinText && matchingStandardLicenseIdsWithinText.isEmpty()) {
+        if (isStandardLicenseWithinText && matchingStandardLicenseIdsWithinText.isEmpty()) {
             result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicensesWithinText()\n");
         }
 

--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -1,0 +1,75 @@
+package org.spdx.utility.compare;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.spdx.library.InvalidSPDXAnalysisException;
+import org.spdx.library.model.license.LicenseInfoFactory;
+import org.spdx.library.model.license.SpdxListedLicense;
+
+public class CompareConsistencyHelper {
+
+    /**
+     * Tests for consistency across the various comparison methods in LicenseCompareHelper, and returns either null
+     * (no inconsistencies found), or a String describing all of the detected inconsistencies.
+     *
+     * Note: assumes that `text` contains just a single license text, with no extraneous prefix or suffix text.
+     *
+     * @param licenseId The SPDX license identifier that's expected to be detected within text.
+     * @param text      The license text being tested.
+     * @return Whether consistency across the APIs under test was found or not.
+     */
+    public static String explainCompareInconsistencies(final String licenseId, final String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
+        StringBuilder result = new StringBuilder();
+
+        // PRECONDITIONS
+        if (licenseId == null || licenseId.trim().length() == 0) {
+            throw new IllegalArgumentException("licenseId was null or blank");
+        }
+
+        if (text == null || text.trim().length() == 0) {
+            throw new IllegalArgumentException("text was null or blank");
+        }
+
+        // Body
+        final SpdxListedLicense listedLicense = LicenseInfoFactory.getListedLicenseById(licenseId);
+
+        if (listedLicense == null) {
+            throw new IllegalArgumentException("could not find listed license for identifier" + licenseId);
+        }
+
+        final boolean      differenceFound                    = LicenseCompareHelper.isTextStandardLicense(listedLicense, text).isDifferenceFound();
+        final boolean      standardLicenseWithinText          = LicenseCompareHelper.isStandardLicenseWithinText(text, listedLicense);
+        final List<String> standardLicensesWithinText         = Arrays.asList(LicenseCompareHelper.matchingStandardLicenseIds(text));
+        final List<String> matchingStandardLicensesWithinText = LicenseCompareHelper.matchingStandardLicenseIdsWithinText(text);
+
+        // Note: we sort the elements because we don't care about different orderings within each list - just that they contain the same elements (in any order)
+        Collections.sort(standardLicensesWithinText);
+        Collections.sort(matchingStandardLicensesWithinText);
+
+        if (differenceFound == standardLicenseWithinText) {  // Note: this condition seems backwards, but only because one variable indicates whether there was a difference, while the other indicates whether the license was found (they're logically opposite)
+            result.append("  * LicenseCompareHelper.isTextStandardLicense() and LicenseCompareHelper.isStandardLicenseWithinText()\n");
+        }
+
+        if (standardLicenseWithinText && (standardLicensesWithinText == null || standardLicensesWithinText.isEmpty())) {
+            result.append("  * LicenseCompareHelper.isStandardLicenseWithinText() and LicenseCompareHelper.matchingStandardLicenseIds()\n");
+        }
+
+        if (standardLicenseWithinText && (matchingStandardLicensesWithinText == null || matchingStandardLicensesWithinText.isEmpty())) {
+            result.append("  * LicenseCompareHelper.isStandardLicenseWithinText() and LicenseCompareHelper.matchingStandardLicensesWithinText()\n");
+        }
+
+        if (!Objects.equals(standardLicensesWithinText, matchingStandardLicensesWithinText)) {
+            result.append("  * LicenseCompareHelper.matchingStandardLicenseIds() and LicenseCompareHelper.matchingStandardLicenseIdsWithinText()");
+        }
+
+        if (result.toString().trim().isEmpty()) {
+            return null;
+        } else {
+            return(("Inconsistencies found between:\n" + result.toString()).trim());
+        }
+    }
+
+}

--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -52,19 +52,19 @@ public class CompareConsistencyHelper {
             result.append("  * .isTextStandardLicense() and .isStandardLicenseWithinText()\n");
         }
 
-        if (!isDifferenceFound && matchingStandardLicenseIds.isEmpty()) {
+        if (!isDifferenceFound && !matchingStandardLicenseIds.contains(licenseId)) {
             result.append("  * .isTextStandardLicense() and .matchingStandardLicenseIds()\n");
         }
 
-        if (!isDifferenceFound && matchingStandardLicenseIdsWithinText.isEmpty()) {
+        if (!isDifferenceFound && !matchingStandardLicenseIdsWithinText.contains(licenseId)) {
             result.append("  * .isTextStandardLicense() and .matchingStandardLicensesWithinText()\n");
         }
 
-        if (isStandardLicenseWithinText && matchingStandardLicenseIds.isEmpty()) {
+        if (isStandardLicenseWithinText && !matchingStandardLicenseIds.contains(licenseId)) {
             result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicenseIds()\n");
         }
 
-        if (isStandardLicenseWithinText && matchingStandardLicenseIdsWithinText.isEmpty()) {
+        if (isStandardLicenseWithinText && !matchingStandardLicenseIdsWithinText.contains(licenseId)) {
             result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicensesWithinText()\n");
         }
 

--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -52,11 +52,19 @@ public class CompareConsistencyHelper {
             result.append("  * .isTextStandardLicense() and .isStandardLicenseWithinText()\n");
         }
 
-        if (isStandardLicenseWithinText && matchingStandardLicenseIds.isEmpty()) {
+        if (!isDifferenceFound && matchingStandardLicenseIds.isEmpty()) {
+            result.append("  * .isTextStandardLicense() and .matchingStandardLicenseIds()\n");
+        }
+
+        if (!isDifferenceFound && matchingStandardLicenseIdsWithinText.isEmpty()) {
+            result.append("  * .isTextStandardLicense() and .matchingStandardLicensesWithinText()\n");
+        }
+
+        if (!isStandardLicenseWithinText && matchingStandardLicenseIds.isEmpty()) {
             result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicenseIds()\n");
         }
 
-        if (isStandardLicenseWithinText && matchingStandardLicenseIdsWithinText.isEmpty()) {
+        if (!isStandardLicenseWithinText && matchingStandardLicenseIdsWithinText.isEmpty()) {
             result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicensesWithinText()\n");
         }
 

--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -12,14 +12,13 @@ import org.spdx.library.model.license.SpdxListedLicense;
 public class CompareConsistencyHelper {
 
     /**
-     * Tests for consistency across the various comparison methods in LicenseCompareHelper, and returns either null
-     * (no inconsistencies found), or a String describing all of the detected inconsistencies.
+     * Tests for consistency across the various comparison methods in LicenseCompareHelper.
      *
      * Note: assumes that `text` contains just a single license text, with no extraneous prefix or suffix text.
      *
-     * @param licenseId The SPDX license identifier that's expected to be detected within text.
-     * @param text      The license text being tested.
-     * @return Whether consistency across the APIs under test was found or not.
+     * @param licenseId The SPDX license identifier that's expected to be detected within `text`.
+     * @param text      The license text being used to test API consistency.
+     * @return null if no inconsistencies were found, or a String describing the detected inconsistencies.
      */
     public static String explainCompareInconsistencies(final String licenseId, final String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
         StringBuilder result = new StringBuilder();

--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -62,13 +62,13 @@ public class CompareConsistencyHelper {
         }
 
         if (!Objects.equals(standardLicensesWithinText, matchingStandardLicensesWithinText)) {
-            result.append("  * LicenseCompareHelper.matchingStandardLicenseIds() and LicenseCompareHelper.matchingStandardLicenseIdsWithinText()");
+            result.append("  * LicenseCompareHelper.matchingStandardLicenseIds() and LicenseCompareHelper.matchingStandardLicenseIdsWithinText()\n");
         }
 
         if (result.toString().trim().isEmpty()) {
             return null;
         } else {
-            return(("Inconsistencies found between:\n" + result.toString()).trim());
+            return(("While testing API consistency with a text known to be " + licenseId + ", inconsistencies were found between:\n" + result.toString()).trim());
         }
     }
 

--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -36,7 +36,7 @@ public class CompareConsistencyHelper {
         final SpdxListedLicense listedLicense = LicenseInfoFactory.getListedLicenseById(licenseId);
 
         if (listedLicense == null) {
-            throw new IllegalArgumentException("could not find listed license for identifier" + licenseId);
+            throw new IllegalArgumentException("Could not find listed license for identifier " + licenseId);
         }
 
         final boolean      differenceFound                    = LicenseCompareHelper.isTextStandardLicense(listedLicense, text).isDifferenceFound();

--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -39,35 +39,35 @@ public class CompareConsistencyHelper {
             throw new IllegalArgumentException("Could not find listed license for identifier " + licenseId);
         }
 
-        final boolean      differenceFound                    = LicenseCompareHelper.isTextStandardLicense(listedLicense, text).isDifferenceFound();
-        final boolean      standardLicenseWithinText          = LicenseCompareHelper.isStandardLicenseWithinText(text, listedLicense);
-        final List<String> standardLicensesWithinText         = Arrays.asList(LicenseCompareHelper.matchingStandardLicenseIds(text));
-        final List<String> matchingStandardLicensesWithinText = LicenseCompareHelper.matchingStandardLicenseIdsWithinText(text);
+        final boolean      isDifferenceFound                    = LicenseCompareHelper.isTextStandardLicense(listedLicense, text).isDifferenceFound();
+        final boolean      isStandardLicenseWithinText          = LicenseCompareHelper.isStandardLicenseWithinText(text, listedLicense);
+        final List<String> matchingStandardLicenseIds           = Arrays.asList(LicenseCompareHelper.matchingStandardLicenseIds(text));
+        final List<String> matchingStandardLicenseIdsWithinText = LicenseCompareHelper.matchingStandardLicenseIdsWithinText(text);
 
-        // Note: we sort the elements because we don't care about different orderings within each list - just that they contain the same elements (in any order)
-        Collections.sort(standardLicensesWithinText);
-        Collections.sort(matchingStandardLicensesWithinText);
+        // Note: we sort these lists because we don't care about different orderings within them - just that they contain the same elements (in any order)
+        Collections.sort(matchingStandardLicenseIds);
+        Collections.sort(matchingStandardLicenseIdsWithinText);
 
-        if (differenceFound == standardLicenseWithinText) {  // Note: this condition seems backwards, but only because one variable indicates whether there was a difference, while the other indicates whether the license was found (they're logically opposite)
-            result.append("  * LicenseCompareHelper.isTextStandardLicense() and LicenseCompareHelper.isStandardLicenseWithinText()\n");
+        if (isDifferenceFound == isStandardLicenseWithinText) {  // Note: this condition seems backwards, but only because one variable indicates whether there was a difference, while the other indicates whether the license was found (they're logically opposite)
+            result.append("  * .isTextStandardLicense() and .isStandardLicenseWithinText()\n");
         }
 
-        if (standardLicenseWithinText && (standardLicensesWithinText == null || standardLicensesWithinText.isEmpty())) {
-            result.append("  * LicenseCompareHelper.isStandardLicenseWithinText() and LicenseCompareHelper.matchingStandardLicenseIds()\n");
+        if (isStandardLicenseWithinText && matchingStandardLicenseIds.isEmpty()) {
+            result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicenseIds()\n");
         }
 
-        if (standardLicenseWithinText && (matchingStandardLicensesWithinText == null || matchingStandardLicensesWithinText.isEmpty())) {
-            result.append("  * LicenseCompareHelper.isStandardLicenseWithinText() and LicenseCompareHelper.matchingStandardLicensesWithinText()\n");
+        if (isStandardLicenseWithinText && matchingStandardLicenseIdsWithinText.isEmpty()) {
+            result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicensesWithinText()\n");
         }
 
-        if (!Objects.equals(standardLicensesWithinText, matchingStandardLicensesWithinText)) {
-            result.append("  * LicenseCompareHelper.matchingStandardLicenseIds() and LicenseCompareHelper.matchingStandardLicenseIdsWithinText()\n");
+        if (!Objects.equals(matchingStandardLicenseIds, matchingStandardLicenseIdsWithinText)) {
+            result.append("  * .matchingStandardLicenseIds() and .matchingStandardLicenseIdsWithinText()\n");
         }
 
         if (result.toString().trim().isEmpty()) {
             return null;
         } else {
-            return(("While testing API consistency with a text known to be " + licenseId + ", inconsistencies were found between:\n" + result.toString()).trim());
+            return(("While testing API consistency with a " + licenseId + " text, inconsistencies were found between LicenseCompareHelper APIs:\n" + result.toString()).trim());
         }
     }
 

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -1080,5 +1080,20 @@ public class LicenseCompareHelperTest extends TestCase {
                 .setTemplate(templateText));
         assertFalse(LicenseCompareHelper.isStandardLicenseWithinText(licText, lic));
     }
-    
+
+	private void consistencyTest(String licenseId, String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
+		final String inconsistencies = CompareConsistencyHelper.explainCompareInconsistencies(licenseId, text);
+		assertNull(inconsistencies, inconsistencies);
+	}
+
+	public void testAPIConsistency() throws InvalidSPDXAnalysisException, SpdxCompareException, IOException {
+		consistencyTest("MIT",          UnitTestHelper.fileToText(MIT_2_SPACES));
+		consistencyTest("BSD-2-Clause", UnitTestHelper.fileToText(BSD_2_CLAUSE_NL));
+
+		if (UnitTestHelper.runSlowTests()) {
+			consistencyTest("GPL-2.0-only", UnitTestHelper.fileToText(GPL_2_TEXT));
+			consistencyTest("MPL-2.0",      UnitTestHelper.fileToText(MPL_2_FROM_MOZILLA_FILE));
+		}
+	}
+
 }

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -1081,7 +1081,7 @@ public class LicenseCompareHelperTest extends TestCase {
         assertFalse(LicenseCompareHelper.isStandardLicenseWithinText(licText, lic));
     }
 
-	private void consistencyTest(String licenseId, String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
+	private void consistencyTest(final String licenseId, final String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
 		final String inconsistencies = CompareConsistencyHelper.explainCompareInconsistencies(licenseId, text);
 		assertNull(inconsistencies, inconsistencies);
 	}

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -1081,18 +1081,18 @@ public class LicenseCompareHelperTest extends TestCase {
         assertFalse(LicenseCompareHelper.isStandardLicenseWithinText(licText, lic));
     }
 
-	private void consistencyTest(final String licenseId, final String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
+	private void assertAPIConsistency(final String licenseId, final String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
 		final String inconsistencies = CompareConsistencyHelper.explainCompareInconsistencies(licenseId, text);
 		assertNull(inconsistencies, inconsistencies);
 	}
 
 	public void testAPIConsistency() throws InvalidSPDXAnalysisException, SpdxCompareException, IOException {
-		consistencyTest("MIT",          UnitTestHelper.fileToText(MIT_2_SPACES));
-		consistencyTest("BSD-2-Clause", UnitTestHelper.fileToText(BSD_2_CLAUSE_NL));
+		assertAPIConsistency("MIT",          UnitTestHelper.fileToText(MIT_2_SPACES));
+		assertAPIConsistency("BSD-2-Clause", UnitTestHelper.fileToText(BSD_2_CLAUSE_NL));
 
 		if (UnitTestHelper.runSlowTests()) {
-			consistencyTest("GPL-2.0-only", UnitTestHelper.fileToText(GPL_2_TEXT));
-			consistencyTest("MPL-2.0",      UnitTestHelper.fileToText(MPL_2_FROM_MOZILLA_FILE));
+			assertAPIConsistency("GPL-2.0-only", UnitTestHelper.fileToText(GPL_2_TEXT));
+			assertAPIConsistency("MPL-2.0",      UnitTestHelper.fileToText(MPL_2_FROM_MOZILLA_FILE));
 		}
 	}
 


### PR DESCRIPTION
This PR adds unit tests that exercise issue #234.  They're (deliberately) minimal, since license comparison is expensive and already a sizable portion of the runtime of the unit tests, but they at least show what's going on with that issue as of v1.11 of the library.

Note: the tests are failing because this PR only adds (previously missing) unit tests to demonstrate issue #234, but not logic to fix it.