### PR TITLE
GH-238: Return `null` if ID does not exist

### DIFF
--- a/src/main/java/org/spdx/library/model/license/ListedLicenses.java
+++ b/src/main/java/org/spdx/library/model/license/ListedLicenses.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.spdx.Configuration;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.SpdxConstants;
+import org.spdx.library.model.SpdxIdNotFoundException;
 import org.spdx.library.model.SpdxModelFactory;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.listedlicense.IListedLicenseStore;
@@ -175,11 +176,19 @@ public class ListedLicenses {
 	 * @throws InvalidSPDXAnalysisException
 	 */
 	public SpdxListedLicense getListedLicenseById(String licenseId) throws InvalidSPDXAnalysisException {
-		return (SpdxListedLicense)SpdxModelFactory.createModelObject(this.licenseModelStore, SpdxConstants.LISTED_LICENSE_URL, licenseId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE, null);
+		try {
+			return (SpdxListedLicense) SpdxModelFactory.getModelObject(this.licenseModelStore, SpdxConstants.LISTED_LICENSE_URL, licenseId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE, null, false);
+		} catch (SpdxIdNotFoundException ex) {
+			return null;
+		}
 	}
 	
 	public ListedLicenseException getListedExceptionById(String exceptionId) throws InvalidSPDXAnalysisException {
-		return (ListedLicenseException)SpdxModelFactory.createModelObject(this.licenseModelStore, SpdxConstants.LISTED_LICENSE_URL, exceptionId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, null);
+		try {
+			return (ListedLicenseException) SpdxModelFactory.getModelObject(this.licenseModelStore, SpdxConstants.LISTED_LICENSE_URL, exceptionId, SpdxConstants.CLASS_SPDX_LISTED_LICENSE_EXCEPTION, null, false);
+		} catch (SpdxIdNotFoundException ex) {
+			return null;
+		}
 	}
 	
 	/**

--- a/src/test/java/org/spdx/library/model/license/ListedLicensesTest.java
+++ b/src/test/java/org/spdx/library/model/license/ListedLicensesTest.java
@@ -80,6 +80,12 @@ public class ListedLicensesTest extends TestCase {
 		assertEquals(id, result.getLicenseId());
 	}
 
+	public void testGetListedLicenseByIdReturnsNull() throws InvalidSPDXAnalysisException {
+		String id = "XXXX";
+		SpdxListedLicense result = ListedLicenses.getListedLicenses().getListedLicenseById(id);
+		assertNull(result);
+	}
+
 	public void testGetLicenseIbyIdLocal() throws InvalidSPDXAnalysisException {
 		System.setProperty("SPDXParser.OnlyUseLocalLicenses", "true");
 		ListedLicenses.resetListedLicenses();
@@ -109,6 +115,14 @@ public class ListedLicensesTest extends TestCase {
 		assertEquals(id, result.getLicenseExceptionId());
 	}
 	
+	public void testGetListedExceptionByIdReturnsNull() throws InvalidSPDXAnalysisException {
+		ListedLicenses.resetListedLicenses();
+		String id = "XXXX";
+		assertFalse(ListedLicenses.getListedLicenses().isSpdxListedExceptionId(id));
+		LicenseException result = ListedLicenses.getListedLicenses().getListedExceptionById(id);
+		assertNull(result);
+	}
+
 	public void testGetExceptionbyIdLocal() throws InvalidSPDXAnalysisException {
 		System.setProperty("SPDXParser.OnlyUseLocalLicenses", "true");
 		ListedLicenses.resetListedLicenses();


### PR DESCRIPTION
`ListedLicenses::getListedLicenseById` and `ListedLicenses::getListedExceptionById` should return `null` if ID does not exist.

Resolves GH-238