### PR TITLE
isStandardLicenseWithinText - match spaces after var rule

### DIFF
--- a/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
+++ b/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
@@ -126,7 +126,7 @@ public class TemplateRegexMatcher implements ILicenseTemplateOutputHandler {
 		
 		@Override
 		public String toString() {
-			return "(" + pattern + ")"; // We always treat the pattern as a group
+			return "(" + pattern + ")" + "\\s*"; // We always treat the pattern as a group
 		}
 
 		/**

--- a/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
+++ b/src/test/java/org/spdx/utility/compare/CompareConsistencyHelper.java
@@ -1,0 +1,83 @@
+package org.spdx.utility.compare;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.spdx.core.InvalidSPDXAnalysisException;
+import org.spdx.library.LicenseInfoFactory;
+import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicense;
+
+
+public class CompareConsistencyHelper {
+
+    /**
+     * Tests for consistency across the various comparison methods in LicenseCompareHelper.
+     *
+     * Note: assumes that `text` contains just a single license text, with no extraneous prefix or suffix text.
+     *
+     * @param licenseId The SPDX license identifier that's expected to be detected within `text`.
+     * @param text      The license text being used to test API consistency.
+     * @return null if no inconsistencies were found, or a String describing the detected inconsistencies.
+     */
+    public static String explainCompareInconsistencies(final String licenseId, final String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
+        StringBuilder result = new StringBuilder();
+
+        // PRECONDITIONS
+        if (licenseId == null || licenseId.trim().length() == 0) {
+            throw new IllegalArgumentException("licenseId was null or blank");
+        }
+
+        if (text == null || text.trim().length() == 0) {
+            throw new IllegalArgumentException("text was null or blank");
+        }
+
+        // Body
+        final ListedLicense listedLicense = LicenseInfoFactory.getListedLicenseById(licenseId);
+
+        if (listedLicense == null) {
+            throw new IllegalArgumentException("Could not find listed license for identifier " + licenseId);
+        }
+
+        final boolean      isDifferenceFound                    = LicenseCompareHelper.isTextStandardLicense(listedLicense, text).isDifferenceFound();
+        final boolean      isStandardLicenseWithinText          = LicenseCompareHelper.isStandardLicenseWithinText(text, listedLicense);
+        final List<String> matchingStandardLicenseIds           = Arrays.asList(LicenseCompareHelper.matchingStandardLicenseIds(text));
+        final List<String> matchingStandardLicenseIdsWithinText = LicenseCompareHelper.matchingStandardLicenseIdsWithinText(text);
+
+        // Note: we sort these lists because we don't care about different orderings within them - just that they contain the same elements (in any order)
+        Collections.sort(matchingStandardLicenseIds);
+        Collections.sort(matchingStandardLicenseIdsWithinText);
+
+        if (isDifferenceFound == isStandardLicenseWithinText) {  // Note: this condition may seem backwards, but only because one variable indicates whether there was a difference, while the other indicates whether the license was found (they're logically opposite)
+            result.append("  * .isTextStandardLicense() and .isStandardLicenseWithinText()\n");
+        }
+
+        if (!isDifferenceFound && !matchingStandardLicenseIds.contains(licenseId)) {
+            result.append("  * .isTextStandardLicense() and .matchingStandardLicenseIds()\n");
+        }
+
+        if (!isDifferenceFound && !matchingStandardLicenseIdsWithinText.contains(licenseId)) {
+            result.append("  * .isTextStandardLicense() and .matchingStandardLicensesWithinText()\n");
+        }
+
+        if (isStandardLicenseWithinText && !matchingStandardLicenseIds.contains(licenseId)) {
+            result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicenseIds()\n");
+        }
+
+        if (isStandardLicenseWithinText && !matchingStandardLicenseIdsWithinText.contains(licenseId)) {
+            result.append("  * .isStandardLicenseWithinText() and .matchingStandardLicensesWithinText()\n");
+        }
+
+        if (!Objects.equals(matchingStandardLicenseIds, matchingStandardLicenseIdsWithinText)) {
+            result.append("  * .matchingStandardLicenseIds() and .matchingStandardLicenseIdsWithinText()\n");
+        }
+
+        if (result.toString().trim().isEmpty()) {
+            return null;
+        } else {
+            return(("While testing API consistency with a " + licenseId + " text, inconsistencies were found between LicenseCompareHelper APIs:\n" + result.toString()).trim());
+        }
+    }
+
+}

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -911,6 +911,8 @@ public class LicenseCompareHelperTest extends TestCase {
         if (diff.isDifferenceFound()) {
         	fail(diff.getDifferenceMessage());
         }
+        boolean result = LicenseCompareHelper.isStandardLicenseWithinText(licText, lic);
+        assertTrue(result);
     }
 
     public void testBsdNewLine() throws InvalidSPDXAnalysisException, SpdxCompareException, IOException {

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -975,4 +975,18 @@ public class LicenseCompareHelperTest extends TestCase {
         assertFalse(LicenseCompareHelper.isStandardLicenseWithinText(licText, lic));
     }
     
+	private void assertAPIConsistency(final String licenseId, final String text) throws InvalidSPDXAnalysisException, SpdxCompareException {
+		final String inconsistencies = CompareConsistencyHelper.explainCompareInconsistencies(licenseId, text);
+		assertNull(inconsistencies, inconsistencies);
+	}
+
+	public void testAPIConsistency() throws InvalidSPDXAnalysisException, SpdxCompareException, IOException {
+		assertAPIConsistency("MIT",          UnitTestHelper.fileToText(MIT_2_SPACES));
+		assertAPIConsistency("BSD-2-Clause", UnitTestHelper.fileToText(BSD_2_CLAUSE_NL));
+
+		if (UnitTestHelper.runSlowTests()) {
+			assertAPIConsistency("GPL-2.0-only", UnitTestHelper.fileToText(GPL_2_TEXT));
+			assertAPIConsistency("MPL-2.0",      UnitTestHelper.fileToText(MPL_2_FROM_MOZILLA_FILE));
+		}
+	}
 }


### PR DESCRIPTION
Fixes #241
Fixes #234

Include code provided by @pmonk in #236 modified for version 2.0+

Thanks @pmonks and @sdheh for your patience and analysis / unit test help!