### PR TITLE
Add support for using LicenseExpression in converter

### DIFF
--- a/src/main/java/org/spdx/library/LicenseInfoFactory.java
+++ b/src/main/java/org/spdx/library/LicenseInfoFactory.java
@@ -32,6 +32,7 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.library.model.v2.license.InvalidLicenseStringException;
 import org.spdx.library.model.v2.license.LicenseParserException;
 import org.spdx.library.model.v2.license.SpdxListedLicense;
+import org.spdx.library.model.v3_0_1.core.CreationInfo;
 import org.spdx.library.model.v3_0_1.core.DictionaryEntry;
 import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicense;
 import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicenseException;
@@ -262,6 +263,14 @@ public class LicenseInfoFactory {
 	 */
 	public static Optional<String> listedExceptionIdCaseSensitive(String exceptionId) {
 		return ListedLicenses.getListedLicenses().listedExceptionIdCaseSensitive(exceptionId);
+	}
+	
+	/**
+	 * @return the CreationInfo used for all SPDX listed licenses and listed exceptions
+	 * @throws InvalidSPDXAnalysisException on error inflating the creation info
+	 */
+	public static CreationInfo getListedLicenseCreationInfo() throws InvalidSPDXAnalysisException {
+		return ListedLicenses.getListedLicenses().getListedLicenseCreationInfo();
 	}
 
 }

--- a/src/main/java/org/spdx/library/ListedLicenses.java
+++ b/src/main/java/org/spdx/library/ListedLicenses.java
@@ -33,6 +33,7 @@ import org.spdx.core.SpdxIdNotFoundException;
 import org.spdx.library.model.v2.SpdxConstantsCompatV2;
 import org.spdx.library.model.v2.SpdxModelFactoryCompatV2;
 import org.spdx.library.model.v2.license.SpdxListedLicense;
+import org.spdx.library.model.v3_0_1.core.CreationInfo;
 import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicense;
 import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicenseException;
 import org.spdx.storage.IModelStore;
@@ -301,6 +302,14 @@ public class ListedLicenses {
 	
 	public IModelStore getLicenseModelStoreCompatV2() {
 		return this.licenseStoreV2;
+	}
+
+	/**
+	 * @return the CreationInfo used for all SPDX listed licenses and listed exceptions
+	 * @throws InvalidSPDXAnalysisException on error inflating the creation info
+	 */
+	public CreationInfo getListedLicenseCreationInfo() throws InvalidSPDXAnalysisException {
+		return licenseStoreV3.getListedLicenseCreationInfo();
 	}
 
 }

--- a/src/main/java/org/spdx/library/ModelCopyManager.java
+++ b/src/main/java/org/spdx/library/ModelCopyManager.java
@@ -196,7 +196,7 @@ public class ModelCopyManager implements IModelCopyManager {
 			}
 			if (SpdxConstantsV3.SpdxMajorVersion.VERSION_2.equals(fromMajorVersion) &&
 					SpdxConstantsV3.SpdxMajorVersion.VERSION_3.equals(toMajorVersion)) {
-				retval = new Spdx2to3Converter(toStore, this, null, toSpecVersion, null);
+				retval = new Spdx2to3Converter(toStore, this, null, toSpecVersion, null, true);
 				//TODO: Add a creation info and uri prefix
 				ISpdxConverter previous = toVersionMap.putIfAbsent(toMajorVersion, retval);
 				if (Objects.nonNull(previous)) {

--- a/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
+++ b/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
@@ -419,6 +419,18 @@ public class Spdx2to3Converter implements ISpdxConverter {
 	 * @param defaultCreationInfo creationInfo to use for created SPDX elements
 	 * @param toSpecVersion specific spec version to convert to
 	 * @param defaultUriPrefix URI prefix to use when creating new elements
+	 */
+	public Spdx2to3Converter(IModelStore toModelStore, IModelCopyManager copyManager, CreationInfo defaultCreationInfo,
+			String toSpecVersion, String defaultUriPrefix) {
+		this(toModelStore, copyManager, defaultCreationInfo, toSpecVersion, defaultUriPrefix, true);
+	}
+	
+	/**
+	 * @param toModelStore modelStore to store any converted elements to
+	 * @param copyManager Copy manager to use for the conversion
+	 * @param defaultCreationInfo creationInfo to use for created SPDX elements
+	 * @param toSpecVersion specific spec version to convert to
+	 * @param defaultUriPrefix URI prefix to use when creating new elements
 	 * @param complexLicenses if true, copy listed license information into the toModelStore and use the ExpandedLicenses otherwise use license expression strings
 	 */
 	public Spdx2to3Converter(IModelStore toModelStore, IModelCopyManager copyManager, CreationInfo defaultCreationInfo,

--- a/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
+++ b/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
@@ -997,7 +997,7 @@ public class Spdx2to3Converter implements ISpdxConverter {
 
 	/**
 	 * Converts an SPDX spec version 2 SPDX AnyLicenseIfno to an SPDX spec version 3 LicenseExpression
-	 * @param fromLicense an SPDX spec version 2 AnyLicenseIfno
+	 * @param fromLicense an SPDX spec version 2 AnyLicenseInfo
 	 * @return an SPDX spec version 3 LicenseExpression
 	 * @throws InvalidSPDXAnalysisException on any errors converting
 	 */
@@ -1032,7 +1032,7 @@ public class Spdx2to3Converter implements ISpdxConverter {
 
 	/**
 	 * Converts an SPDX spec version 2 SPDX AnyLicenseIfno to an SPDX spec version 3 SPDX AnyLicenseIfno and store the result
-	 * @param fromLicense an SPDX spec version 2 AnyLicenseIfno
+	 * @param fromLicense an SPDX spec version 2 AnyLicenseInfo
 	 * @return an SPDX spec version 3 AnyLicenseIfno
 	 * @throws InvalidSPDXAnalysisException on any errors converting
 	 */

--- a/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
+++ b/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
@@ -21,10 +21,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -45,6 +47,7 @@ import org.spdx.library.model.v3_0_1.core.AnnotationType;
 import org.spdx.library.model.v3_0_1.core.CreationInfo;
 import org.spdx.library.model.v3_0_1.core.Element;
 import org.spdx.library.model.v3_0_1.core.ExternalElement;
+import org.spdx.library.model.v3_0_1.core.ExternalIdentifier;
 import org.spdx.library.model.v3_0_1.core.ExternalIdentifierType;
 import org.spdx.library.model.v3_0_1.core.ExternalMap;
 import org.spdx.library.model.v3_0_1.core.ExternalRefType;
@@ -79,6 +82,7 @@ import org.spdx.library.model.v3_0_1.expandedlicensing.NoneLicense;
 import org.spdx.library.model.v3_0_1.expandedlicensing.OrLaterOperator;
 import org.spdx.library.model.v3_0_1.expandedlicensing.WithAdditionOperator;
 import org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo;
+import org.spdx.library.model.v3_0_1.simplelicensing.LicenseExpression;
 import org.spdx.library.model.v3_0_1.software.ContentIdentifierType;
 import org.spdx.library.model.v3_0_1.software.Snippet;
 import org.spdx.library.model.v3_0_1.software.SoftwareArtifact;
@@ -298,6 +302,8 @@ public class Spdx2to3Converter implements ISpdxConverter {
 
 	private int documentIndex = 0;
 
+	private boolean complexLicenses = false;
+
 	/**
 	 * @param creationInfoV2 SPDX Spec version 2 creation info
 	 * @param modelStore modelStore to store the CreationInfo
@@ -413,14 +419,16 @@ public class Spdx2to3Converter implements ISpdxConverter {
 	 * @param defaultCreationInfo creationInfo to use for created SPDX elements
 	 * @param toSpecVersion specific spec version to convert to
 	 * @param defaultUriPrefix URI prefix to use when creating new elements
+	 * @param complexLicenses if true, copy listed license information into the toModelStore and use the ExpandedLicenses otherwise use license expression strings
 	 */
 	public Spdx2to3Converter(IModelStore toModelStore, IModelCopyManager copyManager, CreationInfo defaultCreationInfo,
-			String toSpecVersion, String defaultUriPrefix) {
+			String toSpecVersion, String defaultUriPrefix, boolean complexLicenses) {
 		this.toModelStore = toModelStore;
 		this.defaultCreationInfo = defaultCreationInfo;
 		this.toSpecVersion = toSpecVersion;
 		this.defaultUriPrefix = defaultUriPrefix;
 		this.copyManager = copyManager;
+		this.complexLicenses  = complexLicenses;
 	}
 	
 	/**
@@ -429,6 +437,81 @@ public class Spdx2to3Converter implements ISpdxConverter {
 	 */
 	public boolean alreadyCopied(String fromObjectUri) {
 		return this.alreadyConverted.containsKey(fromObjectUri);
+	}
+	
+	/**
+	 * @param spdx2CreatorInfo SPDX 2 creation information
+	 * @param spdx3CreationInfo SPDX 3 creation information
+	 * @return true of the values of the SPDX 2 creation information are equivalent to the SPDX 3 creation information
+	 * @throws InvalidSPDXAnalysisException on error fetching model data
+	 */
+	private boolean equivalentCreationInfo(SpdxCreatorInformation spdx2CreatorInfo,
+			CreationInfo spdx3CreationInfo) throws InvalidSPDXAnalysisException {
+		if (!Objects.equals(spdx2CreatorInfo.getCreated(), spdx3CreationInfo.getCreated())) {
+			return false;
+		}
+		List<Tool> tools = spdx3CreationInfo.getCreatedUsings().stream().collect(Collectors.toList());
+		List<Agent> agents = spdx3CreationInfo.getCreatedBys().stream().collect(Collectors.toList());
+		for (String creator:spdx2CreatorInfo.getCreators()) {
+			if (creator.startsWith(SpdxConstantsCompatV2.CREATOR_PREFIX_TOOL)) {
+				String toolName = creator.substring(SpdxConstantsCompatV2.CREATOR_PREFIX_TOOL.length()).trim();
+				boolean found = false;
+				for (Tool tool:tools) {
+					if (tool.getName().isPresent() && tool.getName().get().equals(toolName)) {
+						found = true;
+						break;
+					}
+				}
+				if (!found) {
+					return false;
+				}
+			} else {
+				// look for matching agents
+				String name = creator;
+				String type = SpdxConstantsV3.CORE_AGENT;
+				String email = null;
+				Matcher matcher = SPDX_2_CREATOR_PATTERN.matcher(creator);
+				if (matcher.matches()) {
+					if (matcher.group(1).trim().equals("Person")) {
+						type = SpdxConstantsV3.CORE_PERSON;
+					} else if (matcher.group(1).trim().equals("Organization"))  {
+						type = SpdxConstantsV3.CORE_ORGANIZATION;
+					} // otherwise it is just the default AGENT
+					if (matcher.groupCount() > 1) {
+						name = matcher.group(2).trim();
+					} else {
+						name = "[MISSING]";
+					}
+					if (matcher.groupCount() > 3) {
+						email = matcher.group(4);
+					}
+				}
+				boolean found = false;
+				for (Agent agent:agents) {
+					if (agent.getType().equals(type) &&
+							agent.getName().isPresent() && agent.getName().get().equals(name)) {
+						if (Objects.nonNull(email)) {
+							boolean foundEmail = false;
+							for (ExternalIdentifier ei:agent.getExternalIdentifiers()) {
+								if (ExternalIdentifierType.EMAIL.equals(ei.getExternalIdentifierType()) &&
+										email.equals(ei.getIdentifier())) {
+									foundEmail = true;
+									break;
+								}
+							}
+							if (foundEmail) {
+								found = true;
+								break;
+							}
+						}
+					}
+				}
+				if (!found) {
+					return false;
+				}
+			}
+		}
+		return true;
 	}
 	
 	/**
@@ -585,7 +668,9 @@ public class Spdx2to3Converter implements ISpdxConverter {
 			toDoc.getNamespaceMaps().add(convertAndStore(externalDocRef, toDoc.getSpdxImports()));
 		}
 		convertElementProperties(fromDoc, toDoc);
-		toDoc.setCreationInfo(convertCreationInfo(fromDoc.getCreationInfo(), this.toModelStore, this.defaultUriPrefix));
+		if (!equivalentCreationInfo(fromDoc.getCreationInfo(), defaultCreationInfo)) {
+			toDoc.setCreationInfo(convertCreationInfo(fromDoc.getCreationInfo(), this.toModelStore, this.defaultUriPrefix));
+		}
 		toDoc.setDataLicense(convertAndStore(fromDoc.getDataLicense()));
 		toDoc.getRootElements().addAll(fromDoc.getDocumentDescribes().stream().map(spdxElement -> {
 			try {
@@ -601,7 +686,7 @@ public class Spdx2to3Converter implements ISpdxConverter {
 		}
 		return toDoc;
 	}
-	
+
 	/**
 	 * Converts the externalDocRef to a NamespaceMap and store the NamespaceMap.
 	 * The document information is also retained in the externalDocRefMap such that any subsequent 
@@ -765,8 +850,10 @@ public class Spdx2to3Converter implements ISpdxConverter {
 		String licenseId = SpdxListedLicenseModelStore.objectUriToLicenseOrExceptionId(fromSpdxListedLicense.getObjectUri());
 		if (ListedLicenses.getListedLicenses().isSpdxListedLicenseId(licenseId)) {
 			ListedLicense retval = ListedLicenses.getListedLicenses().getListedLicenseById(licenseId);
-			copyManager.copy(toModelStore, fromSpdxListedLicense.getObjectUri(), retval.getModelStore(),
-					fromSpdxListedLicense.getObjectUri(), toSpecVersion, null);
+			if (complexLicenses) {
+				copyManager.copy(toModelStore, fromSpdxListedLicense.getObjectUri(), retval.getModelStore(),
+						fromSpdxListedLicense.getObjectUri(), toSpecVersion, null);
+			}
 			return retval;
 		}
 		ListedLicense toListedLicense = (ListedLicense)SpdxModelClassFactoryV3.getModelObject(toModelStore, 
@@ -880,8 +967,10 @@ public class Spdx2to3Converter implements ISpdxConverter {
 		String exceptionId = SpdxListedLicenseModelStore.objectUriToLicenseOrExceptionId(fromException.getObjectUri());
 		if (ListedLicenses.getListedLicenses().isSpdxListedExceptionId(exceptionId)) {
 			ListedLicenseException retval = ListedLicenses.getListedLicenses().getListedExceptionById(exceptionId);
-			copyManager.copy(toModelStore, fromException.getObjectUri(), retval.getModelStore(),
-					fromException.getObjectUri(), toSpecVersion, null);
+			if (complexLicenses) {
+				copyManager.copy(toModelStore, fromException.getObjectUri(), retval.getModelStore(),
+						fromException.getObjectUri(), toSpecVersion, null);
+			}
 			return retval;
 		}
 		ListedLicenseException toListedException = (ListedLicenseException)SpdxModelClassFactoryV3.getModelObject(toModelStore, 
@@ -895,13 +984,50 @@ public class Spdx2to3Converter implements ISpdxConverter {
 	}
 
 	/**
+	 * Converts an SPDX spec version 2 SPDX AnyLicenseIfno to an SPDX spec version 3 LicenseExpression
+	 * @param fromLicense an SPDX spec version 2 AnyLicenseIfno
+	 * @return an SPDX spec version 3 LicenseExpression
+	 * @throws InvalidSPDXAnalysisException on any errors converting
+	 */
+	public LicenseExpression convertToLicenseExpression(org.spdx.library.model.v2.license.AnyLicenseInfo fromLicense) throws InvalidSPDXAnalysisException {
+		Optional<ModelObjectV3> existing = getExistingObject(fromLicense.getObjectUri(), SpdxConstantsV3.SIMPLE_LICENSING_LICENSE_EXPRESSION);
+		if (existing.isPresent()) {
+			return (LicenseExpression)existing.get();
+		}
+		String toObjectUri = defaultUriPrefix + toModelStore.getNextId(IdType.SpdxId);
+		String existingUri = this.alreadyConverted.putIfAbsent(fromLicense.getObjectUri(), toObjectUri);
+		if (Objects.nonNull(existingUri)) {
+			// small window if conversion occurred since the last check already converted
+			return (LicenseExpression)getExistingObject(fromLicense.getObjectUri(), SpdxConstantsV3.SIMPLE_LICENSING_LICENSE_EXPRESSION).get();
+		}
+		LicenseExpression licenseExpression = (LicenseExpression)SpdxModelClassFactoryV3.getModelObject(toModelStore, 
+				toObjectUri, SpdxConstantsV3.SIMPLE_LICENSING_LICENSE_EXPRESSION, copyManager, true, defaultUriPrefix);
+		licenseExpression.setCreationInfo(defaultCreationInfo);
+		String expression = fromLicense.toString();
+		licenseExpression.setLicenseExpression(expression);
+		StringTokenizer tokenizer = new StringTokenizer(expression, "() ");
+		while (tokenizer.hasMoreTokens()) {
+			String token = tokenizer.nextToken().trim();
+			if (token.startsWith(SpdxConstantsCompatV2.NON_STD_LICENSE_ID_PRENUM)) {
+				licenseExpression.getCustomIdToUris().add(licenseExpression.createDictionaryEntry(toModelStore.getNextId(IdType.Anonymous))
+						.setKey(token)
+						.setValue(defaultUriPrefix + token)
+						.build());
+			}
+		}
+		return licenseExpression;
+	}
+
+	/**
 	 * Converts an SPDX spec version 2 SPDX AnyLicenseIfno to an SPDX spec version 3 SPDX AnyLicenseIfno and store the result
 	 * @param fromLicense an SPDX spec version 2 AnyLicenseIfno
 	 * @return an SPDX spec version 3 AnyLicenseIfno
 	 * @throws InvalidSPDXAnalysisException on any errors converting
 	 */
 	public AnyLicenseInfo convertAndStore(org.spdx.library.model.v2.license.AnyLicenseInfo fromLicense) throws InvalidSPDXAnalysisException {
-		if (fromLicense instanceof org.spdx.library.model.v2.license.ConjunctiveLicenseSet) {
+		if (!complexLicenses) {
+			return convertToLicenseExpression(fromLicense);
+		} else if (fromLicense instanceof org.spdx.library.model.v2.license.ConjunctiveLicenseSet) {
 			return convertAndStore((org.spdx.library.model.v2.license.ConjunctiveLicenseSet)fromLicense);
 		} else if (fromLicense instanceof org.spdx.library.model.v2.license.DisjunctiveLicenseSet) {
 			return convertAndStore((org.spdx.library.model.v2.license.DisjunctiveLicenseSet)fromLicense);

--- a/src/main/java/org/spdx/storage/listedlicense/IListedLicenseStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/IListedLicenseStore.java
@@ -20,6 +20,8 @@ package org.spdx.storage.listedlicense;
 import java.util.List;
 import java.util.Optional;
 
+import org.spdx.core.InvalidSPDXAnalysisException;
+import org.spdx.library.model.v3_0_1.core.CreationInfo;
 import org.spdx.storage.IModelStore;
 
 /**
@@ -70,5 +72,11 @@ public interface IListedLicenseStore extends IModelStore {
 	 * @return case sensitive ID
 	 */
 	Optional<String> listedExceptionIdCaseSensitive(String exceptionId);
+
+	/**
+	 * @return the CreationInfo used for all SPDX listed licenses and listed exceptions
+	 * @throws InvalidSPDXAnalysisException on error inflating the creation info
+	 */
+	CreationInfo getListedLicenseCreationInfo() throws InvalidSPDXAnalysisException;
 
 }

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseCreationInfo.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseCreationInfo.java
@@ -158,5 +158,4 @@ public class LicenseCreationInfo {
 						SpdxConstantsV3.PROP_SPEC_VERSION.equals(propertyDescriptor) ||
 						SpdxConstantsV3.PROP_CREATED.equals(propertyDescriptor));
 	}
-
 }

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
@@ -303,6 +303,11 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	 */
 	@Override
 	public List<PropertyDescriptor> getPropertyValueDescriptors(String objectUri) throws InvalidSPDXAnalysisException  {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			return LicenseCreationInfo.ALL_PROPERTY_DESCRIPTORS;
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			return LicenseCreatorAgent.ALL_PROPERTY_DESCRIPTORS;
+		}
 		String id = objectUriToId(objectUri);
 		listedLicenseModificationLock.readLock().lock();
 		try {
@@ -316,10 +321,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			} else if (crossRefs.containsKey(id)) {
 				return crossRefs.get(id).getPropertyValueDescriptors();
 				// Currently, there is no SPDX 3 support for cross refs
-			} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-				return LicenseCreationInfo.ALL_PROPERTY_DESCRIPTORS;
-			} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-				return LicenseCreatorAgent.ALL_PROPERTY_DESCRIPTORS;
 			} else {
 				logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 				throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID. crossRef ID nor a listed exception ID");
@@ -477,6 +478,13 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	 */
 	@Override
 	public void setValue(String objectUri, PropertyDescriptor propertyDescriptor, Object value)  throws InvalidSPDXAnalysisException  {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			logger.warn("Ignoring the setting of "+propertyDescriptor.getName()+" for license list creation info");
+			return;
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			logger.warn("Ignoring the setting of "+propertyDescriptor.getName()+" for license list creator info");
+			return;
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -501,10 +509,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			exc.setPrimativeValue(propertyDescriptor, value);
 		} else if (Objects.nonNull(crossRef)) {
 			crossRef.setPrimativeValue(propertyDescriptor, value);
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			logger.warn("Ignoring the setting of "+propertyDescriptor.getName()+" for license list creation info");
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			logger.warn("Ignoring the setting of "+propertyDescriptor.getName()+" for license list creator info");
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -516,6 +520,13 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	 */
 	@Override
 	public void clearValueCollection(String objectUri, PropertyDescriptor propertyDescriptor)  throws InvalidSPDXAnalysisException  {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			logger.warn("Ignoring the clearing of collection for license list creation info");
+			return;
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			logger.warn("Ignoring the clearing of collection for license list creator");
+			return;
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -540,10 +551,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			exc.clearPropertyValueList(propertyDescriptor);
 		} else if (Objects.nonNull(crossRef)) {
 			crossRef.clearPropertyValueList(propertyDescriptor);
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			logger.warn("Ignoring the clearing of collection for license list creation info");
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			logger.warn("Ignoring the clearing of collection for license list creator");
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -555,6 +562,13 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	 */
 	@Override
 	public boolean addValueToCollection(String objectUri, PropertyDescriptor propertyDescriptor, Object value)  throws InvalidSPDXAnalysisException  {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			logger.warn("Ignoring the adding to collection for license list creation info");
+			return false;
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			logger.warn("Ignoring the adding to collection for license list creator");
+			return false;
+		} 
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -597,12 +611,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			return exc.addPrimitiveValueToList(propertyDescriptor, value);
 		} else if (Objects.nonNull(crossRef)) {
 			return crossRef.addPrimitiveValueToList(propertyDescriptor, value);
-		}  else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			logger.warn("Ignoring the adding to collection for license list creation info");
-			return false;
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			logger.warn("Ignoring the adding to collection for license list creator");
-			return false;
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -612,6 +620,13 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	@Override
 	public boolean removeValueFromCollection(String objectUri, PropertyDescriptor propertyDescriptor, Object value)
 			throws InvalidSPDXAnalysisException {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			logger.warn("Ignoring the removing from collection for license list creation info");
+			return false;
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			logger.warn("Ignoring the removing from collection for license list creator");
+			return false;
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -654,12 +669,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			return exc.removePrimitiveValueToList(propertyDescriptor, value);
 		} else if (Objects.nonNull(crossRef)) {
 			return crossRef.removePrimitiveValueToList(propertyDescriptor, value);
-		}  else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			logger.warn("Ignoring the removing from collection for license list creation info");
-			return false;
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			logger.warn("Ignoring the removing from collection for license list creator");
-			return false;
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -672,6 +681,11 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	@SuppressWarnings("unchecked")
 	@Override
 	public Iterator<Object> listValues(String objectUri, PropertyDescriptor propertyDescriptor)  throws InvalidSPDXAnalysisException  {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			return ((List<Object>)(List<?>)licenseCreationInfo.getValueList(propertyDescriptor)).iterator();
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			return ((List<Object>)(List<?>)licenseCreator.getValueList(propertyDescriptor)).iterator();
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -743,10 +757,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			return ((List<Object>)(List<?>)exc.getValueList(propertyDescriptor)).iterator();
 		} else if (Objects.nonNull(crossRef)) {
 			return ((List<Object>)(List<?>)crossRef.getValueList(propertyDescriptor)).iterator();
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			return ((List<Object>)(List<?>)licenseCreationInfo.getValueList(propertyDescriptor)).iterator();
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			return ((List<Object>)(List<?>)licenseCreator.getValueList(propertyDescriptor)).iterator();
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -758,6 +768,11 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	 */
 	@Override
 	public Optional<Object> getValue(String objectUri, PropertyDescriptor propertyDescriptor)  throws InvalidSPDXAnalysisException  {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			return Optional.ofNullable(licenseCreationInfo.getValue(propertyDescriptor));
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			return Optional.ofNullable(licenseCreator.getValue(propertyDescriptor));
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -784,10 +799,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			return Optional.ofNullable(exc.getValue(propertyDescriptor));
 		} else if (Objects.nonNull(crossRef)) {
 			return Optional.ofNullable(crossRef.getValue(propertyDescriptor));
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			return Optional.ofNullable(licenseCreationInfo.getValue(propertyDescriptor));
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			return Optional.ofNullable(licenseCreator.getValue(propertyDescriptor));
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -914,6 +925,13 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	
 	@Override
 	public void removeProperty(String objectUri, PropertyDescriptor propertyDescriptor) throws InvalidSPDXAnalysisException {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			logger.warn("Ignoring remove property "+propertyDescriptor.getName()+" for license list creation info");
+			return;
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			logger.warn("Ignoring remove property "+propertyDescriptor.getName()+" for license list creator");
+			return;
+		} 
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -938,10 +956,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			exc.removeProperty(propertyDescriptor);
 		} else if (Objects.nonNull(crossRef)) {
 			crossRef.removeProperty(propertyDescriptor);
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			logger.warn("Ignoring remove property "+propertyDescriptor.getName()+" for license list creation info");
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			logger.warn("Ignoring remove property "+propertyDescriptor.getName()+" for license list creator");
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -997,6 +1011,11 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	@SuppressWarnings("unchecked")
 	@Override
 	public int collectionSize(String objectUri, PropertyDescriptor propertyDescriptor) throws InvalidSPDXAnalysisException {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			return ((List<Object>)(List<?>)licenseCreationInfo.getValueList(propertyDescriptor)).size();
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			return ((List<Object>)(List<?>)licenseCreator.getValueList(propertyDescriptor)).size();
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -1021,10 +1040,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			return ((List<Object>)(List<?>)exc.getValueList(propertyDescriptor)).size();
 		} else if (Objects.nonNull(crossRef)) {
 			return ((List<Object>)(List<?>)crossRef.getValueList(propertyDescriptor)).size();
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			return ((List<Object>)(List<?>)licenseCreationInfo.getValueList(propertyDescriptor)).size();
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			return ((List<Object>)(List<?>)licenseCreator.getValueList(propertyDescriptor)).size();
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -1035,6 +1050,11 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	@Override
 	public boolean collectionContains(String objectUri, PropertyDescriptor propertyDescriptor, Object value)
 			throws InvalidSPDXAnalysisException {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			return ((List<Object>)(List<?>)licenseCreationInfo.getValueList(propertyDescriptor)).contains(value);
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			return ((List<Object>)(List<?>)licenseCreator.getValueList(propertyDescriptor)).contains(value);
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -1069,10 +1089,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			return ((List<Object>)(List<?>)exc.getValueList(propertyDescriptor)).contains(value);
 		} else if (Objects.nonNull(crossRef)) {
 			return ((List<Object>)(List<?>)crossRef.getValueList(propertyDescriptor)).contains(value);
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			return ((List<Object>)(List<?>)licenseCreationInfo.getValueList(propertyDescriptor)).contains(value);
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			return ((List<Object>)(List<?>)licenseCreator.getValueList(propertyDescriptor)).contains(value);
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -1121,6 +1137,11 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	public boolean isPropertyValueAssignableTo(String objectUri, PropertyDescriptor propertyDescriptor, 
 			Class<?> clazz, String specVersion)
 			throws InvalidSPDXAnalysisException {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			return licenseCreationInfo.isPropertyValueAssignableTo(propertyDescriptor, clazz);
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			return licenseCreator.isPropertyValueAssignableTo(propertyDescriptor, clazz);
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -1145,10 +1166,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			return exc.isPropertyValueAssignableTo(propertyDescriptor, clazz);
 		} else if (Objects.nonNull(crossRef)) {
 			return crossRef.isPropertyValueAssignableTo(propertyDescriptor, clazz);
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			return licenseCreationInfo.isPropertyValueAssignableTo(propertyDescriptor, clazz);
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			return licenseCreator.isPropertyValueAssignableTo(propertyDescriptor, clazz);
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, CrossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, CrossRef ID nor a listed exception ID");
@@ -1158,6 +1175,11 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	@Override
 	public boolean isCollectionProperty(String objectUri, PropertyDescriptor propertyDescriptor)
 			throws InvalidSPDXAnalysisException {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			return this.licenseCreationInfo.isCollectionProperty(propertyDescriptor);
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			return licenseCreator.isCollectionProperty(propertyDescriptor);
+		}
 		String id = objectUriToId(objectUri);
 		boolean isLicenseId = false;
 		boolean isExceptionId = false;
@@ -1182,10 +1204,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 			return exc.isCollectionProperty(propertyDescriptor);
 		} else if (Objects.nonNull(crossRef)) {
 			return crossRef.isCollectionProperty(propertyDescriptor.getName());
-		} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-			return this.licenseCreationInfo.isCollectionProperty(propertyDescriptor);
-		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-			return licenseCreator.isCollectionProperty(propertyDescriptor);
 		} else {
 			logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 			throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
@@ -1260,6 +1278,13 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	
 	@Override
 	public void delete(String objectUri) throws InvalidSPDXAnalysisException {
+		if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
+			logger.warn("Ignoring the removal of the creation info for the license list");
+			return;
+		} else if (licenseCreator.getObjectUri().equals(objectUri)) {
+			logger.warn("Ignoring the removal of the creator for the license list");
+			return;
+		}
 		String id = objectUriToId(objectUri);
 		listedLicenseModificationLock.writeLock().lock();
 		try {
@@ -1271,10 +1296,6 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 				this.exceptionIds.remove(id.toLowerCase());
 			} else if (crossRefs.containsKey(id)) {
 				this.crossRefs.remove(id);
-			} else if (LicenseCreationInfo.CREATION_INFO_URI.equals(objectUri)) {
-				logger.warn("Ignoring the removal of the creation info for the license list");
-			} else if (licenseCreator.getObjectUri().equals(objectUri)) {
-				logger.warn("Ignoring the removal of the creator for the license list");
 			} else {
 				logger.error("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");
 				throw new SpdxIdNotFoundException("ID "+id+" is not a listed license ID, crossRef ID nor a listed exception ID");

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxV3ListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxV3ListedLicenseModelStore.java
@@ -29,6 +29,7 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.core.TypedValue;
 import org.spdx.library.model.v2.SpdxConstantsCompatV2;
 import org.spdx.library.model.v3_0_1.SpdxConstantsV3;
+import org.spdx.library.model.v3_0_1.core.CreationInfo;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.PropertyDescriptor;
 
@@ -385,5 +386,13 @@ public class SpdxV3ListedLicenseModelStore implements IModelStore {
 	@Override
 	public boolean isAnon(String objectUri) {
 		return baseStore.isAnon(objectUri);
+	}
+
+	/**
+	 * @return the CreationInfo used for all SPDX listed licenses and listed exceptions
+	 * @throws InvalidSPDXAnalysisException on error inflating the creation info
+	 */
+	public CreationInfo getListedLicenseCreationInfo() throws InvalidSPDXAnalysisException {
+		return baseStore.getListedLicenseCreationInfo();
 	}
 }

--- a/src/test/java/org/spdx/library/conversion/Spdx2to3ConverterTest.java
+++ b/src/test/java/org/spdx/library/conversion/Spdx2to3ConverterTest.java
@@ -22,7 +22,9 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -45,6 +47,7 @@ import org.spdx.library.model.v3_0_1.SpdxModelClassFactoryV3;
 import org.spdx.library.model.v3_0_1.core.Agent;
 import org.spdx.library.model.v3_0_1.core.Annotation;
 import org.spdx.library.model.v3_0_1.core.CreationInfo;
+import org.spdx.library.model.v3_0_1.core.DictionaryEntry;
 import org.spdx.library.model.v3_0_1.core.Element;
 import org.spdx.library.model.v3_0_1.core.ExternalElement;
 import org.spdx.library.model.v3_0_1.core.ExternalIdentifier;
@@ -78,6 +81,7 @@ import org.spdx.library.model.v3_0_1.expandedlicensing.NoneLicense;
 import org.spdx.library.model.v3_0_1.expandedlicensing.OrLaterOperator;
 import org.spdx.library.model.v3_0_1.expandedlicensing.WithAdditionOperator;
 import org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo;
+import org.spdx.library.model.v3_0_1.simplelicensing.LicenseExpression;
 import org.spdx.library.model.v3_0_1.software.Snippet;
 import org.spdx.library.model.v3_0_1.software.SpdxFile;
 import org.spdx.library.model.v3_0_1.software.SpdxPackage;
@@ -181,7 +185,7 @@ public class Spdx2to3ConverterTest {
 	@Test
 	public void testSpdx2to3Converter() {
 		Spdx2to3Converter result = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		assertFalse(result.alreadyCopied(DOCUMENT_URI));
 	}
 
@@ -198,7 +202,7 @@ public class Spdx2to3ConverterTest {
 		licV2.setExtractedText("Extracted Text");
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		assertFalse(converter.alreadyCopied(DOCUMENT_URI + "#" + licenseId));
 		converter.convertAndStore(licV2);
 		assertTrue(converter.alreadyCopied(DOCUMENT_URI + "#" + licenseId));
@@ -257,7 +261,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		SpdxDocument result = converter.convertAndStore(doc);
 		
 		List<Relationship> resultRelationships = new ArrayList<>();
@@ -335,7 +339,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		SpdxDocument result = converter.convertAndStore(doc);
 		
 		List<Relationship> resultRelationships = new ArrayList<>();
@@ -406,7 +410,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		SpdxDocument result = converter.convertAndStore(doc);
 		
 		List<Relationship> resultRelationships = new ArrayList<>();
@@ -447,7 +451,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		DisjunctiveLicenseSet result = converter.convertAndStore(ors);
 		AnyLicenseInfo[] members = result.getMembers().toArray(new AnyLicenseInfo[result.getMembers().size()]);
 		assertEquals(2, members.length);
@@ -482,7 +486,7 @@ public class Spdx2to3ConverterTest {
 		licV2.setExtractedText("Extracted Text");
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		assertFalse(converter.getExistingObject(DOCUMENT_URI + "#" + licenseId, SpdxConstantsV3.EXPANDED_LICENSING_CUSTOM_LICENSE).isPresent());
 		
 		CustomLicense customLicense = converter.convertAndStore(licV2);
@@ -587,7 +591,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		SpdxDocument result = converter.convertAndStore(doc);
 		assertEquals(docComment, result.getComment().get());
 		assertEquals(dataLicenseStr, result.getDataLicense().get().toString());
@@ -677,7 +681,7 @@ public class Spdx2to3ConverterTest {
 				new org.spdx.library.model.v2.ExternalDocumentRef(fromModelStore, DOCUMENT_URI, externalDocumentId, copyManager, true);
 		externalDocRef.setSpdxDocumentNamespace(externalDocumentUri);
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		Collection<ExternalMap> docImports = new ArrayList<>();
 		NamespaceMap result = converter.convertAndStore(externalDocRef, docImports);
 		assertEquals(externalDocumentId, result.getPrefix());
@@ -741,7 +745,7 @@ public class Spdx2to3ConverterTest {
 				.build();
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		
 		SpdxPackage packageElement = converter.convertAndStore(pkg);
 		List<String> verify = packageElement.verify();
@@ -887,7 +891,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		SpdxFile file = converter.convertAndStore(spdxFile);
 		Annotation result = converter.convertAndStore(annotation, file);
 		
@@ -940,7 +944,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		LicenseAddition result = converter.convertAndStore(licException);
 		assertTrue(result instanceof ListedLicenseException);
 		assertEquals(exceptionComment, result.getComment().get());
@@ -963,7 +967,7 @@ public class Spdx2to3ConverterTest {
 		org.spdx.library.model.v2.ExternalSpdxElement externalElement = 
 				new org.spdx.library.model.v2.ExternalSpdxElement(fromModelStore, externalDocumentUri, externalId, copyManager, true);
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		Element result = converter.convertAndStore((org.spdx.library.model.v2.SpdxElement)externalElement);
 		assertTrue(result instanceof ExternalElement);
 		List<String> verify = result.verify();
@@ -1088,7 +1092,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		Hash result = converter.convertAndStore(checksum);
 		assertEquals(checksumAlgorithm.toString(), result.getAlgorithm().toString());
 		assertEquals(value, result.getHashValue());
@@ -1122,7 +1126,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		ConjunctiveLicenseSet result = converter.convertAndStore(ands);
 		AnyLicenseInfo[] members = result.getMembers().toArray(new AnyLicenseInfo[result.getMembers().size()]);
 		assertEquals(2, members.length);
@@ -1170,7 +1174,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		DisjunctiveLicenseSet result = converter.convertAndStore(ors);
 		AnyLicenseInfo[] members = result.getMembers().toArray(new AnyLicenseInfo[result.getMembers().size()]);
 		assertEquals(2, members.length);
@@ -1216,7 +1220,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		CustomLicense result = converter.convertAndStore(licV2);
 		assertEquals(extractedLicComment, result.getComment().get());
 		assertEquals(extractedText, result.getLicenseText());
@@ -1248,7 +1252,7 @@ public class Spdx2to3ConverterTest {
 		List<String> verify = orLater.verify();
 		assertTrue(verify.isEmpty());
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		OrLaterOperator result = converter.convertAndStore(orLater);
 		assertEquals(extractedText, result.getSubjectLicense().getLicenseText());
 		assertEquals(extractedLicName, result.getSubjectLicense().getName().get());
@@ -1295,7 +1299,7 @@ public class Spdx2to3ConverterTest {
 		assertEquals(1, verify.size()); // deprecated ID causes a warning
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		ListedLicense result = converter.convertAndStore(listedLicense);
 		assertEquals(licenseComment, result.getComment().get());
 		assertEquals(deprecated, result.getIsDeprecatedLicenseId().get());
@@ -1335,7 +1339,7 @@ public class Spdx2to3ConverterTest {
 		List<String> verify = withException.verify();
 		assertTrue(verify.isEmpty());
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		WithAdditionOperator result = converter.convertAndStore(withException);
 		assertTrue(result.getSubjectExtendableLicense().getObjectUri().endsWith("Apache-2.0"));
 		assertEquals(exceptionText, result.getSubjectAddition().getAdditionText());
@@ -1348,7 +1352,7 @@ public class Spdx2to3ConverterTest {
 	@Test
 	public void testConvertAndStoreAnyLicenseInfo() throws InvalidSPDXAnalysisException {	
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		
 		// org.spdx.library.model.v2.license.ExtractedLicenseInfo;
 		String extractedText = "Extracted text";
@@ -1524,7 +1528,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		SpdxFile result = converter.convertAndStore(spdxFile);
 		List<Relationship> resultRelationships = new ArrayList<>();
 		SpdxModelFactory.getSpdxObjects(toModelStore, copyManager, SpdxConstantsV3.CORE_RELATIONSHIP, DEFAULT_PREFIX, DEFAULT_PREFIX).forEach(rel -> resultRelationships.add((Relationship)rel));
@@ -1670,7 +1674,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		SpdxPackage result = converter.convertAndStore(pkg);
 		List<Relationship> resultRelationships = new ArrayList<>();
 		SpdxModelFactory.getSpdxObjects(toModelStore, copyManager, SpdxConstantsV3.CORE_RELATIONSHIP, DEFAULT_PREFIX, DEFAULT_PREFIX).forEach(rel -> resultRelationships.add((Relationship)rel));
@@ -1811,7 +1815,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		Snippet result = converter.convertAndStore(snippet);
 		
 		List<Relationship> resultRelationships = new ArrayList<>();
@@ -1889,7 +1893,7 @@ public class Spdx2to3ConverterTest {
 		assertTrue(verify.isEmpty());
 		
 		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
-				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX);
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
 		LicenseAddition result = converter.convertAndStore((org.spdx.library.model.v2.license.LicenseException)licException);
 		assertTrue(result instanceof ListedLicenseException);
 		assertEquals(exceptionComment, result.getComment().get());
@@ -1902,6 +1906,54 @@ public class Spdx2to3ConverterTest {
 		assertTrue(result.getSeeAlsos().containsAll(exceptionSeeAlsos));
 		verify = result.verify();
 		assertTrue(verify.isEmpty());
+	}
+	
+	@Test
+	public void testConvertToLicenseExpression() throws InvalidSPDXAnalysisException {
+		String extractedText = "Extracted text1";
+		String extractedLicName = "name";
+		String extractedText2 = "Extracted text2";
+		String extractedLicName2 = "name2";
+		String licId1 = fromModelStore.getNextId(IdType.LicenseRef);
+		String licId2 = fromModelStore.getNextId(IdType.LicenseRef);
+		org.spdx.library.model.v2.license.ExtractedLicenseInfo lic1 = 
+				new org.spdx.library.model.v2.license.ExtractedLicenseInfo(fromModelStore, DOCUMENT_URI, licId1,
+						copyManager, true);
+		lic1.setName(extractedLicName);
+		lic1.setExtractedText(extractedText);
+		org.spdx.library.model.v2.license.AnyLicenseInfo lic2 = 
+				LicenseInfoFactory.parseSPDXLicenseStringCompatV2("Apache-2.0", fromModelStore, DOCUMENT_URI, copyManager);
+		
+		org.spdx.library.model.v2.license.ConjunctiveLicenseSet ands = 
+				new org.spdx.library.model.v2.license.ConjunctiveLicenseSet(fromModelStore, DOCUMENT_URI, fromModelStore.getNextId(IdType.Anonymous),
+						copyManager, true);
+		org.spdx.library.model.v2.license.ExtractedLicenseInfo lic3 = 
+				new org.spdx.library.model.v2.license.ExtractedLicenseInfo(fromModelStore, DOCUMENT_URI, licId2,
+						copyManager, true);
+		lic3.setName(extractedLicName2);
+		lic3.setExtractedText(extractedText2);
+		ands.addMember(lic1);
+		ands.addMember(lic2);
+		ands.addMember(lic3);
+		List<String> verify = ands.verify();
+		assertTrue(verify.isEmpty());
+		
+		Spdx2to3Converter converter = new Spdx2to3Converter(toModelStore, copyManager, defaultCreationInfo, 
+				SpdxModelFactory.getLatestSpecVersion(), DEFAULT_PREFIX, true);
+		
+		LicenseExpression result = converter.convertToLicenseExpression(ands);
+		Map<String, String> expected = new HashMap<>();
+		expected.put(licId1, DEFAULT_PREFIX + licId1);
+		expected.put(licId2, DEFAULT_PREFIX + licId2);
+		for (DictionaryEntry entry:result.getCustomIdToUris()) {
+			String id = entry.getKey();
+			String uri = entry.getValue().get();
+			assertTrue(expected.containsKey(id));
+			assertEquals(expected.get(id), uri);
+			expected.remove(id);
+		}
+		assertTrue(expected.isEmpty());
+		assertEquals(ands.toString(), result.getLicenseExpression());
 	}
 
 }


### PR DESCRIPTION
Adds an option to the Spdx2to3Converter to use simple licensing license expressions instead of the
ExpandedLicensing fully modelled license expressions

Also includes a fix for #250