### PR TITLE
Fix few typos and add a language id to code blocks

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -4,9 +4,9 @@
 
 ### Programmatically Creating SPDX Data
 
-Before executing any of the model class methods, the model versions need to be intialized.  This is done by calling:
+Before executing any of the model class methods, the model versions need to be initialized.  This is done by calling:
 
-```
+```java
 SpdxModelFactory.init();
 ```
 
@@ -14,18 +14,18 @@ SPDX data is stored in a "model store" and copying between model stores requires
 
 A simple store is provided in the java library.  To create the simple in-memory model store and a copy manager, execute the following:
 
-```
+```java
 InMemSpdxStore modelStore = new InMemSpdxStore();
 IModelCopyManager copyManager = new ModelCopyManager();
 ```
 
 All SPDX elements are required to have a unique SPDX ID which is an Object URI.  In the SPDX Java libraries, this is commonly referred to as the `objectUri` to avoid confusion with the SPDX 2.X version short SPDX IDs.
 
-A good practice is to create a common prefix to use for your programatic session.  The prefix should be unique to the session.  There are convenience methods in the library to append identifiers uniques to the model store.
+A good practice is to create a common prefix to use for your programmatic session.  The prefix should be unique to the session.  There are convenience methods in the library to append identifiers unique to the model store.
 
 In these examples, we'll use:
 
-```
+```java
 String prefix = "https://org.spdx.spdxdata/899b1918-f72a-4755-9215-6262b3c346df/";
 ```
 
@@ -33,7 +33,7 @@ Since SPDX 3.0 requires creation info on every element, the easiest way to start
 
 For example:
 
-```
+```java
 CreationInfo creationInfo = SpdxModelClassFactory.createCreationInfo(
 			modelStore, prefix + "Agent/Gary01123", "Gary O'Neall",
 			copyManager);
@@ -43,7 +43,7 @@ We're now ready to create our first SPDX element.  You can start anywhere, but l
 
 There is a factory method you can use to get started:
 
-```
+```java
 Sbom sbom = SpdxModelClassFactory.getModelObject(modelStore, 
 			prefix + "sbom/mysbom", SpdxConstantsV3.SOFTWARE_SBOM, 
 			copyManager, true, prefix);
@@ -51,7 +51,7 @@ Sbom sbom = SpdxModelClassFactory.getModelObject(modelStore,
 
 Let's not forget to add the creation info:
 
-```
+```java
 sbom.setCreationInfo(creationInfo);
 ```
 
@@ -59,7 +59,7 @@ From here on, things get easier.  We can get and set properties to the sbom we j
 
 If we want to create another SPDX object or element, we can use the builder convenience methods available to all SPDX objects.  For example, if we want to create a package to add to the SBOM we can call:
 
-```
+```java
 sbom.getElements().add(
 			sbom.createSpdxPackage(prefix + "package/mypackage")
 			.setName("Package Name")

--- a/README-SPI-MODEL-STORE.md
+++ b/README-SPI-MODEL-STORE.md
@@ -9,13 +9,14 @@ NOTE: This README is currently under development.
 ## Storing and Retrieving Values
 
 ### Converting Object Types
+
 The class org.spdx.library.ModelStorageClassConverter contains static methods to convert object types supported by the SPI.
 
 storedObjectToModelObject will convert a stored object to a Model object.
 
 modelObjectToStoredObject will convert a model object to a stored object.
 
-These methods should be used to avoid common errors when converting between supported object types. 
+These methods should be used to avoid common errors when converting between supported object types.
 
 ## Using the Serialization interfaces
 

--- a/README-V3-UPGRADE.md
+++ b/README-V3-UPGRADE.md
@@ -22,6 +22,7 @@ The packages in `org.spdx.licenseTemplates` are now in the `java-spdx-core` repo
 A new class `LicenseTextHelper` was added and the method `isLicenseTextEquivalent(String, String)` along with many supporting methods were moved to `LicenseTextHelper` from `org.spdx.utility.compare.LicenseCompareHelper`.
 
 ## Changes to SPDX version 2 package, class, and method names
+
 To support accessing SPDX 2.X model object while updating the library for SPDX 3.0 support, the package names for the SPDX 2.X model objects are now named `org.spdx.library.model.v2.[package]`.
 
 Many of the class and property names have been changed to append `CompatV2` to clearly designate a compatible object is being referenced.
@@ -37,14 +38,16 @@ will check for the old DocumentRef format and attempt a conversion.
 Note that this incompatibility was introduced due to using a common mode store API which in some cases will not have the documentUri as a required parameter
 
 ## Changes to deserialize interface
+
 Since SPDX documents are not generally required in SPDX spec version 3.0, the SPDX namespace was removed from the return value for deserialized and also removed as a parameter for the serialize method.  Serialize will now serialize all objects - which may be multiple SPDX documents.
 
 To find all the SPDX documents in a serialization, you can execute:
 
-```
+```java
 List<SpdxDocument> docs = (List<SpdxDocument>)SpdxModelFactory.getSpdxObjects(store, null, SpdxConstantsCompatV2.CLASS_SPDX_DOCUMENT, null, null)
 				.collect(Collectors.toList());
 ```
+
 after deserialization to get a list of all SPDX documents.
 
 For the RDF store, to keep compatible with the SPDX 2.X requirements, it now only supports a single document namespace.
@@ -54,9 +57,9 @@ For the RDF store, to keep compatible with the SPDX 2.X requirements, it now onl
 ### Change propertyName to propertyDescriptor
 
 One significant change to the model store which impacts most of the API's.
-All `String` `propertyName` properties are replaced by a `propertyDescriptor` of type `ProperyDescriptor`.
+All `String` `propertyName` properties are replaced by a `propertyDescriptor` of type `PropertyDescriptor`.
 The `PropertyDescriptor` has a `name` property and a `nameSpace` property.
-The property constants defined in  `org.spdx.library.SpdxConstants` have all been changed to use constant `PropertyDescriptor`s.
+The property constants defined in `org.spdx.library.SpdxConstants` have all been changed to use constant `PropertyDescriptor`s.
 If you're using the constants, you may not need to change much beyond the method signatures for anything that was passing along the `propertyName`.
 
 ### Make DocumentNamespace Optional

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Spdx-Java-Library
+
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.spdx/java-spdx-library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.spdx/java-spdx-library)
 ![Java CI with Maven](https://github.com/spdx/Spdx-Java-Library/workflows/Java%20CI%20with%20Maven/badge.svg)
 
 Java library which implements the Java object model for SPDX and provides useful helper functions.
 
-# Code quality badges
+## Code quality badges
 
 |   [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=java-spdx-library&metric=bugs)](https://sonarcloud.io/dashboard?id=java-spdx-library)    | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=java-spdx-library&metric=security_rating)](https://sonarcloud.io/dashboard?id=java-spdx-library) | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=java-spdx-library&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=java-spdx-library) | [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=java-spdx-library&metric=sqale_index)](https://sonarcloud.io/dashboard?id=java-spdx-library) |
 
@@ -17,17 +18,21 @@ The library does support the spec versions 2.X and 3.X.
 See the [README-V3-UPGRADE.md](README-V3-UPGRADE.md) file for information on how to upgrade from earlier versions of the library.
 
 ## Storage Interface
+
 The Spdx-Java-Library allows for different implementations of SPDX object storage.  The storage facility implements the org.spdx.storage.IModelStore interface.  This is a low level Service Provider Interface (SPI).  The ISerializableModelStore extends the IModelStore and supports serializing and de-serializing the store to an I/O Stream. This interface is currently used to implement JSON, XML, YAML, and RDF/XML formats.  The default storage interface is an in-memory Map which should be sufficient for light weight usage of the library.
 
-Most common use of the library would  de-serialize an existing SPDX document using one of the supported formats and model stores.  To create SPDX objects from scratch, simply create the Java objects found in the org.spdx.library.model package.  The model follows the [SPDX Object Model](https://github.com/spdx/spdx-spec/blob/2a7aff7afa089a774916bd5c64fc2cb83637ea07/model/SPDX-UML-Class-Diagram.jpg).  The model objects themselves are stateless and do not store information.  All information is retrieved from the model store when properties are access.  Storage to the classes will store the updates through the use of the storage interface.
+Most common use of the library would de-serialize an existing SPDX document using one of the supported formats and model stores.  To create SPDX objects from scratch, simply create the Java objects found in the org.spdx.library.model package.  The model follows the [SPDX Object Model](https://github.com/spdx/spdx-spec/blob/2a7aff7afa089a774916bd5c64fc2cb83637ea07/model/SPDX-UML-Class-Diagram.jpg).  The model objects themselves are stateless and do not store information.  All information is retrieved from the model store when properties are access.  Storage to the classes will store the updates through the use of the storage interface.
 
 ## Multi-Threaded Considerations
+
 The methods enterCriticalSection and leaveCritialSection are available to support multi-threaded applications.  These methods serialize access to the model store for the specific SPDX document used for the SPDX model object.
 
 ## Getting Started
+
 The library is available in [Maven Central org.spdx:java-spdx-library](https://search.maven.org/artifact/org.spdx/java-spdx-library).
 
 If you are using Maven, you can add the following dependency in your POM file:
+
 ```xml
 <dependency>
   <groupId>org.spdx</groupId>
@@ -43,12 +48,12 @@ There are a couple of static classes that help common usage scenarios:
 - org.spdx.library.SpdxModelFactory supports the creation of specific model objects
 - org.spdx.library.model.license.LicenseInfoFactory supports the parsing of SPDX license expressions, creation, and comparison of SPDX licenses
 
-
 ## Configuration options
 
 `Spdx-Java-Library` can be configured using either Java system properties or a Java properties file located in the runtime CLASSPATH at `/resources/spdx-java-library.properties`.
 
 The library has these configuration options:
+
 1. `org.spdx.useJARLicenseInfoOnly` - a boolean that controls whether the (potentially out of date) listed license information bundled inside the JAR is used (true), vs the library downloading the latest files from the SPDX website (false). Default is false (always download the latest files from the SPDX website).
 2. `org.spdx.downloadCacheEnabled` - a boolean that enables or disables the download cache. Defaults to `false` (the cache is disabled). The cache location is determined as per the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) (i.e. `${XDG_CACHE_HOME}/Spdx-Java-Library` or `${HOME}/.cache/Spdx-Java-Library`).
 3. `org.spdx.downloadCacheCheckIntervalSecs` - a long that controls how often each cache entry is rechecked for staleness, in units of seconds. Defaults to 86,400 seconds (24 hours). Set to 0 (zero) to have each cache entry checked every time (note: this will result in a lot more network I/O and negatively impact performance, albeit there is still a substantial performance saving vs not using the cache at all).
@@ -57,13 +62,15 @@ Note that these configuration options can only be modified prior to first use of
 
 The first thing that needs to be done in your implementation is call `SpdxModelFactory.init()` - this will load all the supported versions.
 
-If you are programatically creating SPDX data, you will start by creating a model store.  The simplest model store is an in-memory model store which can be created with `store = new InMemSpdxStore()`.  A copy manager will be needed if you are working with more than one store (e.g. a serialized format of SPDX data and in memory).  If you're not sure, you should just create one.  This can be done with `copyManager = new ModelCopyManager()`.
+If you are programmatically creating SPDX data, you will start by creating a model store.  The simplest model store is an in-memory model store which can be created with `store = new InMemSpdxStore()`.  A copy manager will be needed if you are working with more than one store (e.g. a serialized format of SPDX data and in memory).  If you're not sure, you should just create one.  This can be done with `copyManager = new ModelCopyManager()`.
 
 The first object you create will depend on the major version:
+
 - For SPDX 2.X, you would start by creating an SpdxDocument.  The factory method `SpdxDocument document = SpdxModelFactory.createSpdxDocumentV2(IModelStore modelStore, String documentUri, IModelCopyManager copyManager)` will create a new SPDX document.  Once created, you can use the setters to set the specific fields.  You can then use the convenience create methods on the document to create additional SPDX objects (e.g. `document.createSpdxFile(...)`);
-- For SPDX 3.X, you will start with a CreationInfo class.  The factory method `CreationInfo creationInfo = SpdxModelClassFactory.createCreationInfo(IModelStore modelStore, String createdByUri,String createdByName, @Nullable IModelCopyManager copyManager)` will create and initialize a CreationInfo with today's date and the Agent information.  To create any additional objects, you can use the builder convenience methods from the creationInfo (or any Elements created by the creationInfo) (e.g. `creationInfo.createSoftwareSpdxFile(String spdxFileObjectUri)`.  The created objects will copy the creationInfo.
+- For SPDX 3.X, you will start with a CreationInfo class.  The factory method `CreationInfo creationInfo = SpdxModelClassFactory.createCreationInfo(IModelStore modelStore, String createdByUri,String createdByName, @Nullable IModelCopyManager copyManager)` will create and initialize a CreationInfo with today's date and the Agent information.  To create any additional objects, you can use the builder convenience methods from the creationInfo (or any Elements created by the creationInfo) e.g. `creationInfo.createSoftwareSpdxFile(String spdxFileObjectUri)`.  The created objects will copy the creationInfo.
 
 ## Update for new versions of the spec
+
 To update Spdx-Java-Library, the following is a very brief checklist:
 
   1. Create a Java .jar file for the new version which contains an implementation of `ISpdxModelInfo` - typically named SpdxModelInfoVXXX - where XXX is the version of the spec.
@@ -72,4 +79,5 @@ To update Spdx-Java-Library, the following is a very brief checklist:
   4. Update SpdxModelFactory unit test for the highest version check
 
 ## Development Status
+
 Note: This library is currently unstable, and under development.  Reviews, suggestions are welcome.  Please enter an issue with any suggestions.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Most common use of the library would de-serialize an existing SPDX document usin
 
 ## Multi-Threaded Considerations
 
-The methods enterCriticalSection and leaveCritialSection are available to support multi-threaded applications.  These methods serialize access to the model store for the specific SPDX document used for the SPDX model object.
+The methods enterCriticalSection and leaveCriticalSection are available to support multi-threaded applications.  These methods serialize access to the model store for the specific SPDX document used for the SPDX model object.
 
 ## Getting Started
 


### PR DESCRIPTION
- intialized -> initialized
- programatic -> programmatic
- leaveCritialSection -> leaveCriticalSection
- etc.
