### PR TITLE
Change logging for license list I/O error

### DIFF
--- a/src/main/java/org/spdx/library/ListedLicenses.java
+++ b/src/main/java/org/spdx/library/ListedLicenses.java
@@ -118,7 +118,8 @@ public class ListedLicenses {
         		try {
         			baseModelStore = new SpdxListedLicenseWebStore();
         		} catch(InvalidSPDXAnalysisException ex) {
-        			logger.error("Unable to access the most current listed licenses from https://spdx.org/licenses - using locally cached licenses: "+ex.getMessage());
+        			logger.warn("Unable to access the most current listed licenses from https://spdx.org/licenses - using locally cached licenses: "+ex.getMessage()+
+        					" Note: you can set the org.spdx.useJARLicenseInfoOnly property to true to avoid this warning.");
         			baseModelStore = null;
         		}
         	}


### PR DESCRIPTION
Changes the logging level from error to warn if the license list can not be accessed over the network.  The logic being that the impact is not substantial since you may only be referencing a stale version of the license list rather than the most recent.

The warning message was also enhanced to point to the `useJARLicenseInfoOnly` property.

Reference related issue https://github.com/spdx/spdx-maven-plugin/issues/172