### PR TITLE
Fix minor typos in docstrings

### DIFF
--- a/src/main/java/org/spdx/library/ModelCopyManager.java
+++ b/src/main/java/org/spdx/library/ModelCopyManager.java
@@ -105,7 +105,7 @@ public class ModelCopyManager implements IModelCopyManager {
 	
 	/**
 	 * @param fromStore Store copied from
-	 * @param fromObjectUri Object URI in the from tsotre
+	 * @param fromObjectUri Object URI in the fromStore
 	 * @param toStore store copied to
 	 * @return the objectId which has already been copied, or null if it has not been copied
 	 */

--- a/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
+++ b/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
@@ -379,8 +379,8 @@ public class Spdx2to3Converter implements ISpdxConverter {
 					SpdxConstantsV3.CORE_ORGANIZATION, creationInfo.getCopyManager(), true, creationInfo.getIdPrefix());
 			organization.setCreationInfo(creationInfo);
 			if (matcher.groupCount() > 1) {
-				String origanizationName = matcher.group(2).trim();
-				organization.setName(origanizationName);
+				String organizationName = matcher.group(2).trim();
+				organization.setName(organizationName);
 			} else {
 				logger.warn("Missing organization name");
 				organization.setName("[MISSING]");
@@ -940,7 +940,7 @@ public class Spdx2to3Converter implements ISpdxConverter {
 	
 	/**
 	 * Convert and add properties from the fromException to the toAddition
-	 * @param fromException SPDX spec verion 2 LicenseException to copy properties from
+	 * @param fromException SPDX spec version 2 LicenseException to copy properties from
 	 * @param toAddition SPDX spec version 3 LicenseAddition to copy properties to
 	 * @throws InvalidSPDXAnalysisException on any errors converting
 	 */
@@ -992,7 +992,7 @@ public class Spdx2to3Converter implements ISpdxConverter {
 	}
 
 	/**
-	 * Converts an SPDX spec version 2 SPDX AnyLicenseIfno to an SPDX spec version 3 LicenseExpression
+	 * Converts an SPDX spec version 2 SPDX AnyLicenseInfo to an SPDX spec version 3 LicenseExpression
 	 * @param fromLicense an SPDX spec version 2 AnyLicenseInfo
 	 * @return an SPDX spec version 3 LicenseExpression
 	 * @throws InvalidSPDXAnalysisException on any errors converting
@@ -1027,9 +1027,9 @@ public class Spdx2to3Converter implements ISpdxConverter {
 	}
 
 	/**
-	 * Converts an SPDX spec version 2 SPDX AnyLicenseIfno to an SPDX spec version 3 SPDX AnyLicenseIfno and store the result
+	 * Converts an SPDX spec version 2 SPDX AnyLicenseInfo to an SPDX spec version 3 SPDX AnyLicenseInfo and store the result
 	 * @param fromLicense an SPDX spec version 2 AnyLicenseInfo
-	 * @return an SPDX spec version 3 AnyLicenseIfno
+	 * @return an SPDX spec version 3 AnyLicenseInfo
 	 * @throws InvalidSPDXAnalysisException on any errors converting
 	 */
 	public AnyLicenseInfo convertAndStore(org.spdx.library.model.v2.license.AnyLicenseInfo fromLicense) throws InvalidSPDXAnalysisException {
@@ -1201,7 +1201,7 @@ public class Spdx2to3Converter implements ISpdxConverter {
 	}
 
 	/**
-	 * Adds a Sotfware Purpose to a SoftwareArtifact.  If the primaryPurpose is already used, add as an additionalPurpose
+	 * Adds a Software Purpose to a SoftwareArtifact.  If the primaryPurpose is already used, add as an additionalPurpose
 	 * @param purpose purpose to add
 	 * @param artifact artifact to add the purpose to
 	 * @throws InvalidSPDXAnalysisException on any error in conversion

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
@@ -121,25 +121,25 @@ public abstract class SpdxListedLicenseModelStore implements IListedLicenseStore
 	}
 	
 	/**
-	 * @return InputStream for the Table of Contents of the licenses formated in JSON SPDX
+	 * @return InputStream for the Table of Contents of the licenses formatted in JSON SPDX
 	 * @throws IOException on IO errors
 	 */
 	public abstract InputStream getTocInputStream() throws IOException;
 	
 	/**
-	 * @return InputStream for the Table of Contents of the exceptions formated in JSON SPDX
+	 * @return InputStream for the Table of Contents of the exceptions formatted in JSON SPDX
 	 * @throws IOException on IO errors
 	 */
 	public abstract InputStream getExceptionTocInputStream() throws IOException;
 	
 	/**
-	 * @return InputStream for a license formated in SPDX JSON
+	 * @return InputStream for a license formatted in SPDX JSON
 	 * @throws IOException on IO errors
 	 */
 	public abstract InputStream getLicenseInputStream(String licenseId) throws IOException;
 	
 	/**
-	 * @return InputStream for an exception formated in SPDX JSON
+	 * @return InputStream for an exception formatted in SPDX JSON
 	 * @throws IOException on IO errors
 	 */
 	public abstract InputStream getExceptionInputStream(String exceptionId) throws IOException;


### PR DESCRIPTION
Fix typos that are not related to public/protected methods