### PR TITLE
Remove unnecessary warning

### DIFF
--- a/src/main/java/org/spdx/library/ModelCopyManager.java
+++ b/src/main/java/org/spdx/library/ModelCopyManager.java
@@ -448,7 +448,10 @@ public class ModelCopyManager implements IModelCopyManager {
 		}
 		if (Objects.isNull(toNamespace) || toNamespace.isEmpty() || 
 				sourceUri.startsWith(toNamespace)) {
-            logger.warn("{} already exists - possibly overwriting properties due to a copy from a different model store.", sourceUri);
+			if (!sourceUri.startsWith("https://spdx.org")) {
+				// It is not a pre-defined SPDX URI
+				logger.warn("{} already exists - possibly overwriting properties due to a copy from a different model store.", sourceUri);
+			}
 			return sourceUri;
 		}
 		switch (idType) {


### PR DESCRIPTION
With the introduction of standard creation infos in SPDX 3.0.1, we will be copying the same URIs to different model stores.  This removes the warning when this occurs.

Partial fix for https://github.com/spdx/tools-java/issues/170