### PR TITLE
Remove unused compiler and javadoc options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,6 @@
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>
-					<optimize>true</optimize>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -233,9 +232,6 @@
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<configuration>
-							<additionalparam>${javadoc.opts}</additionalparam>
-						</configuration>
 						<goals>
 							<goal>jar</goal>
 						</goals>


### PR DESCRIPTION
The `optimize` tag is deprecated and a noop, and `javadoc.opts` is not set anywhere.
