### PR TITLE
Call `SpdxModelFactory::init` when constructing `LicenseCreatorAgent`

### DIFF
--- a/src/main/java/org/spdx/storage/listedlicense/LicenseCreatorAgent.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseCreatorAgent.java
@@ -27,6 +27,7 @@ import org.spdx.core.ModelRegistryException;
 import org.spdx.core.SpdxInvalidIdException;
 import org.spdx.core.SpdxInvalidTypeException;
 import org.spdx.core.TypedValue;
+import org.spdx.library.SpdxModelFactory;
 import org.spdx.library.model.v3_0_1.SpdxConstantsV3;
 import org.spdx.library.model.v3_0_1.core.Agent;
 import org.spdx.library.model.v3_0_1.core.CreationInfo;
@@ -51,6 +52,7 @@ public class LicenseCreatorAgent {
 	private final TypedValue creationInfoTV;
 	
 	public LicenseCreatorAgent(String licenseListVersion) throws SpdxInvalidIdException, SpdxInvalidTypeException, ModelRegistryException {
+		SpdxModelFactory.init();
 		this.objectUri = OBJECT_URI_PREFIX + licenseListVersion.replace('.','_');
 		this.typedValue = new TypedValue(objectUri, SpdxConstantsV3.CORE_AGENT, SpdxConstantsV3.MODEL_SPEC_VERSION);
 		this.creationInfoTV = new TypedValue(LicenseCreationInfo.CREATION_INFO_URI, SpdxConstantsV3.CORE_CREATION_INFO, SpdxConstantsV3.MODEL_SPEC_VERSION);

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseCreatorAgent.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseCreatorAgent.java
@@ -52,6 +52,8 @@ public class LicenseCreatorAgent {
 	private final TypedValue creationInfoTV;
 	
 	public LicenseCreatorAgent(String licenseListVersion) throws SpdxInvalidIdException, SpdxInvalidTypeException, ModelRegistryException {
+               // Call init to make sure the model is initialized before it is used by the license factory methods
+               // Note that multiple calls to init does not cause any harm
 		SpdxModelFactory.init();
 		this.objectUri = OBJECT_URI_PREFIX + licenseListVersion.replace('.','_');
 		this.typedValue = new TypedValue(objectUri, SpdxConstantsV3.CORE_AGENT, SpdxConstantsV3.MODEL_SPEC_VERSION);


### PR DESCRIPTION
Is something like this possible? It could remove the need to manually call `SpdxModelFactory::init`.