### PR TITLE
Add SPDX-FileCopyrightText and SPDX-FileType to source file header

### DIFF
--- a/src/main/java/org/spdx/Configuration.java
+++ b/src/main/java/org/spdx/Configuration.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2023 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/LicenseInfoFactory.java
+++ b/src/main/java/org/spdx/library/LicenseInfoFactory.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/ListedLicenses.java
+++ b/src/main/java/org/spdx/library/ListedLicenses.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/ModelCopyManager.java
+++ b/src/main/java/org/spdx/library/ModelCopyManager.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/SpdxConversionException.java
+++ b/src/main/java/org/spdx/library/SpdxConversionException.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/SpdxModelFactory.java
+++ b/src/main/java/org/spdx/library/SpdxModelFactory.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/conversion/ExternalMapInfo.java
+++ b/src/main/java/org/spdx/library/conversion/ExternalMapInfo.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/conversion/ISpdxConverter.java
+++ b/src/main/java/org/spdx/library/conversion/ISpdxConverter.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
+++ b/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/library/conversion/package-info.java
+++ b/src/main/java/org/spdx/library/conversion/package-info.java
@@ -1,14 +1,14 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * 
+ * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *
+ * <p>
  *       http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/spdx/library/package-info.java
+++ b/src/main/java/org/spdx/library/package-info.java
@@ -1,20 +1,21 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * 
+ * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *
+ * <p>
  *       http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
+
 /**
  * Functions for reading, writing, and manipulating SPDX documents
  * <p>

--- a/src/main/java/org/spdx/storage/listedlicense/CrossRefJson.java
+++ b/src/main/java/org/spdx/storage/listedlicense/CrossRefJson.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/ExceptionJson.java
+++ b/src/main/java/org/spdx/storage/listedlicense/ExceptionJson.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/ExceptionJsonTOC.java
+++ b/src/main/java/org/spdx/storage/listedlicense/ExceptionJsonTOC.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/IListedLicenseStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/IListedLicenseStore.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseCreationInfo.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseCreationInfo.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseCreatorAgent.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseCreatorAgent.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseJson.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseJson.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseJsonTOC.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseJsonTOC.java
@@ -1,5 +1,7 @@
 /**
- * Copyright (c) 2018 Source Auditor Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2018 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,7 +27,6 @@ import javax.annotation.Nullable;
 import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.library.model.v2.SpdxConstantsCompatV2;
 import org.spdx.library.model.v2.license.SpdxListedLicense;
-
 
 
 /**

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseLocalStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseLocalStore.java
@@ -1,14 +1,14 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * 
+ * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *
+ * <p>
  *       http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseModelStore.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseWebStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxListedLicenseWebStore.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxV2ListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxV2ListedLicenseModelStore.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/SpdxV3ListedLicenseModelStore.java
+++ b/src/main/java/org/spdx/storage/listedlicense/SpdxV3ListedLicenseModelStore.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/listedlicense/package-info.java
+++ b/src/main/java/org/spdx/storage/listedlicense/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
+
 /**
  * Storage for SPDX listed licenses
  * <p>

--- a/src/main/java/org/spdx/storage/simple/ExtendedSpdxStore.java
+++ b/src/main/java/org/spdx/storage/simple/ExtendedSpdxStore.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/simple/InMemSpdxStore.java
+++ b/src/main/java/org/spdx/storage/simple/InMemSpdxStore.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
+++ b/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
@@ -1,3 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package org.spdx.storage.simple;
 
 import java.util.ArrayList;

--- a/src/main/java/org/spdx/storage/simple/package-info.java
+++ b/src/main/java/org/spdx/storage/simple/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/DownloadCache.java
+++ b/src/main/java/org/spdx/utility/DownloadCache.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2023 Peter Monks
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Peter Monks
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/CompareTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/utility/compare/CompareTemplateOutputHandler.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/FilterTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/utility/compare/FilterTemplateOutputHandler.java
@@ -1,12 +1,14 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *
+ * <p>
  *       http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/SpdxCompareException.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxCompareException.java
@@ -1,3 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package org.spdx.utility.compare;
 
 /**

--- a/src/main/java/org/spdx/utility/compare/SpdxComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxComparer.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/SpdxExternalRefDifference.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxExternalRefDifference.java
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- *
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/org/spdx/utility/compare/SpdxFileComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxFileComparer.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/SpdxFileDifference.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxFileDifference.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/SpdxItemComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxItemComparer.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/SpdxItemDifference.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxItemDifference.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/SpdxLicenseDifference.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxLicenseDifference.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/SpdxPackageComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxPackageComparer.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/SpdxSnippetComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxSnippetComparer.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
+++ b/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2023 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/compare/package-info.java
+++ b/src/main/java/org/spdx/utility/compare/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/license/LicenseExpressionParser.java
+++ b/src/main/java/org/spdx/utility/license/LicenseExpressionParser.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/license/LicenseParserException.java
+++ b/src/main/java/org/spdx/utility/license/LicenseParserException.java
@@ -1,3 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package org.spdx.utility.license;
 
 import org.spdx.core.InvalidSPDXAnalysisException;

--- a/src/main/java/org/spdx/utility/license/package-info.java
+++ b/src/main/java/org/spdx/utility/license/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2024 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/package-info.java
+++ b/src/main/java/org/spdx/utility/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/spdx/utility/verificationcode/IFileChecksumGenerator.java
+++ b/src/main/java/org/spdx/utility/verificationcode/IFileChecksumGenerator.java
@@ -1,5 +1,7 @@
 /**
- * Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -12,8 +14,7 @@
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
- *
-*/
+ */
 package org.spdx.utility.verificationcode;
 
 import java.io.File;

--- a/src/main/java/org/spdx/utility/verificationcode/JavaSha1ChecksumGenerator.java
+++ b/src/main/java/org/spdx/utility/verificationcode/JavaSha1ChecksumGenerator.java
@@ -1,5 +1,7 @@
 /**
- * Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -12,8 +14,7 @@
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
- *
-*/
+ */
 package org.spdx.utility.verificationcode;
 
 import java.io.File;

--- a/src/main/java/org/spdx/utility/verificationcode/VerificationCodeGenerator.java
+++ b/src/main/java/org/spdx/utility/verificationcode/VerificationCodeGenerator.java
@@ -1,5 +1,7 @@
 /**
- * Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -12,8 +14,7 @@
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
- *
-*/
+ */
 package org.spdx.utility.verificationcode;
 
 import java.io.File;

--- a/src/main/java/org/spdx/utility/verificationcode/package-info.java
+++ b/src/main/java/org/spdx/utility/verificationcode/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
+
 /**
  * Classes used to generate PackageVerificationCodes
  *


### PR DESCRIPTION
Context: In FOSDEM 2025 SBOM side event and someone complain about source-file-level SBOM information
(in general for the whole industry, not particularly this library).