### PR TITLE
Check for end index being greater then start in TemplateRegexMatcher

### DIFF
--- a/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
+++ b/src/main/java/org/spdx/utility/compare/TemplateRegexMatcher.java
@@ -318,8 +318,10 @@ public class TemplateRegexMatcher implements ILicenseTemplateOutputHandler {
 				startIndex = startMatcher.start();
 				Pattern endPattern = Pattern.compile(getEndRegex(WORD_LIMIT));
 				Matcher endMatcher = endPattern.matcher(compareText);
-				if (endMatcher.find()) {
+				while (endMatcher.find() && endMatcher.start() >= startIndex) {
 					endIndex = endMatcher.end();
+				}
+				if (endIndex > 0) {
 					result = compareText.substring(startIndex, endIndex);
 				}
 			}


### PR DESCRIPTION
Fixes #242

We need to add a unit test before completion