### PR TITLE
Issue 305: Address incorrect index offset for failed token in differences

### DIFF
--- a/src/main/java/org/spdx/utility/compare/CompareTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/utility/compare/CompareTemplateOutputHandler.java
@@ -217,7 +217,7 @@ public class CompareTemplateOutputHandler implements
 					}
 					nextToken = compareText(textTokens, matchTokens, nextToken, this);
 					if (nextToken < 0) {
-						int errorLocation = -nextToken;
+						int errorLocation = -nextToken - 1;
 						differences.addDifference(tokenToLocation.get(errorLocation), LicenseTextHelper.getTokenAt(matchTokens, errorLocation), 
 										"Normal text of license does not match", text, null, getLastOptionalDifference());
 					}

--- a/src/test/java/org/spdx/utility/compare/TestCompareTemplateOutputHandler.java
+++ b/src/test/java/org/spdx/utility/compare/TestCompareTemplateOutputHandler.java
@@ -27,8 +27,12 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.spdx.licenseTemplate.*;
+import org.spdx.licenseTemplate.LicenseParserException;
+import org.spdx.licenseTemplate.LicenseTemplateRule;
+import org.spdx.licenseTemplate.LicenseTemplateRuleException;
+import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
 import org.spdx.licenseTemplate.LicenseTemplateRule.RuleType;
+import org.spdx.licenseTemplate.LineColumn;
 
 /**
  * Test compare template output handler
@@ -49,12 +53,12 @@ public class TestCompareTemplateOutputHandler {
     static final String APACHE_1_0_TEMPLATE = "TestFiles" + File.separator + "Apache-1.0.template.txt";
     static final String BSD_2_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-2-Clause.txt";
     static final String BSD_2_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause.template.txt";
-    static final String BSD_4_CLAUSE_UC_TEXT = "TestFiles" + File.separator + "BSD-4-Clause-UC.txt";
-    static final String BSD_4_CLAUSE_UC_TEMPLATE = "TestFiles" + File.separator + "BSD-4-Clause-UC.template.txt";
-    static final String BSD_4_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-4-Clause.txt";
-    static final String BSD_4_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-4-Clause.template.txt";
-    static final String CROSSWORD_TEXT = "TestFiles" + File.separator + "Crossword.txt";
-    static final String CROSSWORD_TEMPLATE = "TestFiles" + File.separator + "Crossword.template.txt";
+    static final String BSD_4_CLAUSE_UC_TEXT  = "TestFiles" + File.separator + "BSD-4-Clause-UC.txt";
+    static final String BSD_4_CLAUSE_UC_TEMPLATE  = "TestFiles" + File.separator + "BSD-4-Clause-UC.template.txt";
+    static final String BSD_4_CLAUSE_TEXT  = "TestFiles" + File.separator + "BSD-4-Clause.txt";
+    static final String BSD_4_CLAUSE_TEMPLATE  = "TestFiles" + File.separator + "BSD-4-Clause.template.txt";
+    static final String CROSSWORD_TEXT  = "TestFiles" + File.separator + "Crossword.txt";
+    static final String CROSSWORD_TEMPLATE  = "TestFiles" + File.separator + "Crossword.template.txt";
     static final String DFSL_TEXT = "TestFiles" + File.separator + "D-FSL-1.0.txt";
     static final String DFSL_TEMPLATE = "TestFiles" + File.separator + "D-FSL-1.0.template.txt";
     static final String CONDOR_1_1_TEXT = "TestFiles" + File.separator + "Condor-1.1.txt";
@@ -124,7 +128,6 @@ public class TestCompareTemplateOutputHandler {
 
     /**
      * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#CompareTemplateOutputHandler(java.lang.String)}.
-     *
      * @throws Exception
      */
     @Test
@@ -136,57 +139,56 @@ public class TestCompareTemplateOutputHandler {
 
     /**
      * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
-     *
      * @throws LicenseTemplateRuleException
      */
     @Test
-    public void testOptionalText() throws Exception {
+    public void testOptionalText()  throws Exception {
         String l1 = "Line 1\n";
         String l2 = "Line 2\n";
         String l3 = "Line 3\n";
         String l4 = "Line 4";
         // optional in middle
-        String compareText = l1 + l4;
+        String compareText = l1+l4;
         CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
         ctoh.text(l1);
         ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
         ctoh.text(l2);
         ctoh.text(l3);
-        ctoh.endOptional(new LicenseTemplateRule("EndOptional", RuleType.END_OPTIONAL));
+        ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
         ctoh.text(l4);
         ctoh.completeParsing();
         assertTrue(ctoh.matches());
 
         // optional at beginning
-        compareText = l3 + l4;
+        compareText = l3+l4;
         ctoh = new CompareTemplateOutputHandler(compareText);
         ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
         ctoh.text(l1);
         ctoh.text(l2);
-        ctoh.endOptional(new LicenseTemplateRule("EndOptional", RuleType.END_OPTIONAL));
+        ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
         ctoh.text(l3);
         ctoh.text(l4);
         ctoh.completeParsing();
         assertTrue(ctoh.matches());
         // optional at end
-        compareText = l1 + l2 + l3;
+        compareText = l1+l2+l3;
         ctoh = new CompareTemplateOutputHandler(compareText);
         ctoh.text(l1);
         ctoh.text(l2);
         ctoh.text(l3);
         ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
         ctoh.text(l4);
-        ctoh.endOptional(new LicenseTemplateRule("EndOptional", RuleType.END_OPTIONAL));
+        ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
         ctoh.completeParsing();
         assertTrue(ctoh.matches());
         // optional code present
-        compareText = l1 + l2 + l3 + l4;
+        compareText = l1+l2+l3+l4;
         ctoh = new CompareTemplateOutputHandler(compareText);
         ctoh.text(l1);
         ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
         ctoh.text(l2);
         ctoh.text(l3);
-        ctoh.endOptional(new LicenseTemplateRule("EndOptional", RuleType.END_OPTIONAL));
+        ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
         ctoh.text(l4);
         ctoh.completeParsing();
         assertTrue(ctoh.matches());
@@ -204,33 +206,33 @@ public class TestCompareTemplateOutputHandler {
         String l2R = "## Line 2 with replaceable analog canceled stuff\n";
         String l3 = "Line\n";
         String l4 = "Line 4";
-        String compareText = l1 + l2 + l3 + l4;
+        String compareText = l1+l2+l3+l4;
         CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-        int nextToken = ctoh.textEquivalent(l1, 0);
+        int nextToken = ctoh.textEquivalent(l1,0);
         assertTrue(nextToken > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l2, nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l3, nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l4, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l2,nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
         // after end of compare string
-        assertTrue((nextToken = ctoh.textEquivalent(l4, nextToken)) < 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) < 0);
 
         // difference in string
         ctoh = new CompareTemplateOutputHandler(compareText);
-        assertTrue((nextToken = ctoh.textEquivalent(l4, 0)) < 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l4,0)) < 0);
 
         // skippable tokens
         ctoh = new CompareTemplateOutputHandler(compareText);
-        assertTrue((nextToken = ctoh.textEquivalent(l1S, 0)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l2S, nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l3, nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l4, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l1S,0)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l2S,nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
 
         // equivalent tokens
         ctoh = new CompareTemplateOutputHandler(compareText);
-        assertTrue((nextToken = ctoh.textEquivalent(l1, 0)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l2R, nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l3, nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l4, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l1,0)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l2R,nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
     }
 
     /**
@@ -270,11 +272,10 @@ public class TestCompareTemplateOutputHandler {
 
     /**
      * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#variableRule(org.spdx.licenseTemplate.LicenseTemplateRule)}.
-     *
      * @throws LicenseTemplateRuleException
      */
     @Test
-    public void testVariableRule() throws Exception {
+    public void testVariableRule()  throws Exception {
         String line1 = "this is line one\n";
         String line2 = "this line 2 is another line\n";
         String line2Match = "this\\sline\\s.+another\\sline";
@@ -286,7 +287,7 @@ public class TestCompareTemplateOutputHandler {
         CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
         ctoh.text(line1);
         LicenseTemplateRule variableRule = new LicenseTemplateRule("Variable Rule",
-                RuleType.VARIABLE, line2, line2Match, "Example: " + line2);
+                RuleType.VARIABLE, line2, line2Match, "Example: "+line2);
         ctoh.variableRule(variableRule);
         ctoh.text(line3);
         ctoh.completeParsing();
@@ -297,7 +298,7 @@ public class TestCompareTemplateOutputHandler {
         ctoh = new CompareTemplateOutputHandler(partialCompareText);
         ctoh.text(line1);
         variableRule = new LicenseTemplateRule("Variable Rule",
-                RuleType.VARIABLE, line2, line2Match, "Example: " + line2);
+                RuleType.VARIABLE, line2, line2Match, "Example: "+line2);
         ctoh.variableRule(variableRule);
         ctoh.completeParsing();
         assertTrue(ctoh.matches());
@@ -306,7 +307,7 @@ public class TestCompareTemplateOutputHandler {
         ctoh = new CompareTemplateOutputHandler(compareText);
         ctoh.text(line1);
         variableRule = new LicenseTemplateRule("Variable Rule",
-                RuleType.VARIABLE, line2, line2MissMatch, "Example: " + line2);
+                RuleType.VARIABLE, line2, line2MissMatch, "Example: "+line2);
         ctoh.variableRule(variableRule);
         ctoh.text(line3);
         ctoh.completeParsing();
@@ -315,7 +316,7 @@ public class TestCompareTemplateOutputHandler {
         // Extra word
         ctoh = new CompareTemplateOutputHandler(compareText);
         variableRule = new LicenseTemplateRule("Variable Rule",
-                RuleType.VARIABLE, line2, line2PartialMatch, "Example: " + line2);
+                RuleType.VARIABLE, line2, line2PartialMatch, "Example: "+line2);
         ctoh.variableRule(variableRule);
         ctoh.text(line3);
         ctoh.completeParsing();
@@ -657,7 +658,9 @@ public class TestCompareTemplateOutputHandler {
         String compareText = "a b\tc d e f g h i j k l m n o p\nq r s t u v w x y z end";
         CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
         SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+
         System.out.println(templateOutputHandler.getDifferences().getDifferenceMessage());
+
         if (templateOutputHandler.matches()) {
             fail(templateOutputHandler.getDifferences().getDifferenceMessage());
         }

--- a/src/test/java/org/spdx/utility/compare/TestCompareTemplateOutputHandler.java
+++ b/src/test/java/org/spdx/utility/compare/TestCompareTemplateOutputHandler.java
@@ -41,538 +41,538 @@ import org.spdx.licenseTemplate.LineColumn;
  */
 public class TestCompareTemplateOutputHandler {
 
-    static final String ADOBE_GLYPH_TEXT = "TestFiles" + File.separator + "Adobe-Glyph.txt";
-    static final String ADOBE_GLYPH_TEMPLATE = "TestFiles" + File.separator + "Adobe-Glyph.template.txt";
-    static final String AAL_TEXT = "TestFiles" + File.separator + "AAL.txt";
-    static final String AAL_TEMPLATE = "TestFiles" + File.separator + "AAL.template.txt";
-    static final String AFL_3_TEXT = "TestFiles" + File.separator + "AFL-3.0.txt";
-    static final String AFL_3_TEMPLATE = "TestFiles" + File.separator + "AFL-3.0.template.txt";
-    static final String BSDNETBSD_TEXT = "TestFiles" + File.separator + "BSD-2-Clause-NetBSD.txt";
-    static final String BSDNETBSD_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause-NetBSD.template.txt";
-    static final String APACHE_1_0_TEXT = "TestFiles" + File.separator + "Apache-1.0.txt";
-    static final String APACHE_1_0_TEMPLATE = "TestFiles" + File.separator + "Apache-1.0.template.txt";
-    static final String BSD_2_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-2-Clause.txt";
-    static final String BSD_2_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause.template.txt";
-    static final String BSD_4_CLAUSE_UC_TEXT  = "TestFiles" + File.separator + "BSD-4-Clause-UC.txt";
-    static final String BSD_4_CLAUSE_UC_TEMPLATE  = "TestFiles" + File.separator + "BSD-4-Clause-UC.template.txt";
-    static final String BSD_4_CLAUSE_TEXT  = "TestFiles" + File.separator + "BSD-4-Clause.txt";
-    static final String BSD_4_CLAUSE_TEMPLATE  = "TestFiles" + File.separator + "BSD-4-Clause.template.txt";
-    static final String CROSSWORD_TEXT  = "TestFiles" + File.separator + "Crossword.txt";
-    static final String CROSSWORD_TEMPLATE  = "TestFiles" + File.separator + "Crossword.template.txt";
-    static final String DFSL_TEXT = "TestFiles" + File.separator + "D-FSL-1.0.txt";
-    static final String DFSL_TEMPLATE = "TestFiles" + File.separator + "D-FSL-1.0.template.txt";
-    static final String CONDOR_1_1_TEXT = "TestFiles" + File.separator + "Condor-1.1.txt";
-    static final String CONDOR_1_1_TEMPLATE = "TestFiles" + File.separator + "Condor-1.1.template.txt";
-    static final String ISC_TEXT = "TestFiles" + File.separator + "ISC.txt";
-    static final String ISC_TEMPLATE = "TestFiles" + File.separator + "ISC.template.txt";
-    static final String MPL_1_TEXT = "TestFiles" + File.separator + "MPL-1.0.txt";
-    static final String MPL_1_TEMPLATE = "TestFiles" + File.separator + "MPL-1.0.template.txt";
-    static final String RPSL_1_TEXT = "TestFiles" + File.separator + "RPSL-1.0.txt";
-    static final String RPSL_1_TEMPLATE = "TestFiles" + File.separator + "RPSL-1.0.template.txt";
-    static final String RSCPL_TEXT = "TestFiles" + File.separator + "RSCPL.txt";
-    static final String RSCPL_TEMPLATE = "TestFiles" + File.separator + "RSCPL.template.txt";
-    static final String HPND_TEXT = "TestFiles" + File.separator + "HPND.txt";
-    static final String HPND_TEMPLATE = "TestFiles" + File.separator + "HPND.template.txt";
-    static final String CECILL2_TEXT = "TestFiles" + File.separator + "CECILL-2.0.txt";
-    static final String CECILL2_TEMPLATE = "TestFiles" + File.separator + "CECILL-2.0.template.txt";
-    static final String BSD_1_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-1-Clause.txt";
-    static final String BSD_1_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-1-Clause.template.txt";
-    static final String LPPL_1_3_A_TEXT = "TestFiles" + File.separator + "LPPL-1.3a.txt";
-    static final String LPPL_1_3_A_TEMPLATE = "TestFiles" + File.separator + "LPPL-1.3a.template.txt";
-    static final String LPPL_1_3_C_TEXT = "TestFiles" + File.separator + "LPPL-1.3c.txt";
-    static final String LPPL_1_3_C_TEMPLATE = "TestFiles" + File.separator + "LPPL-1.3c.template.txt";
-    static final String ODBL_1_TEXT = "TestFiles" + File.separator + "ODbL-1.0.txt";
-    static final String ODBL_1_TEMPLATE = "TestFiles" + File.separator + "ODbL-1.0.template.txt";
-    static final String SLEEPYCAT_TEXT = "TestFiles" + File.separator + "Sleepycat.txt";
-    static final String SLEEPYCAT_TEMPLATE = "TestFiles" + File.separator + "Sleepycat.template.txt";
-    static final String SSPL_1_0_TEXT = "TestFiles" + File.separator + "SSPL-1.0.txt";
-    static final String SSPL_1_0_TEMPLATE = "TestFiles" + File.separator + "SSPL-1.0.template.txt";
-    static final String AGPL_3_0_ONLY_TEXT = "TestFiles" + File.separator + "AGPL-3.0-only.txt";
-    static final String AGPL_3_0_ONLY_TEMPLATE = "TestFiles" + File.separator + "AGPL-3.0-only.template.txt";
-    static final String BSD_PROTECTION_TEXT = "TestFiles" + File.separator + "BSD-Protection.txt";
-    static final String BSD_PROTECTION_TEMPLATE = "TestFiles" + File.separator + "BSD-Protection.template.txt";
-    static final String BSD_2_CLAUSE_VIEW_TEXT = "TestFiles" + File.separator + "BSD-2-Clause-Views.txt";
-    static final String BSD_2_CLAUSE_VIEW_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause-Views.template.txt";
-    static final String EUPL_1_2_TEXT = "TestFiles" + File.separator + "EUPL-1.2.txt";
-    static final String EUPL_1_2_TEMPLATE = "TestFiles" + File.separator + "EUPL-1.2.template.txt";
-    static final String GD_TEXT = "TestFiles" + File.separator + "GD.txt";
-    static final String GD_TEMPLATE = "TestFiles" + File.separator + "GD.template.txt";
+	static final String ADOBE_GLYPH_TEXT = "TestFiles" + File.separator + "Adobe-Glyph.txt";
+	static final String ADOBE_GLYPH_TEMPLATE = "TestFiles" + File.separator + "Adobe-Glyph.template.txt";
+	static final String AAL_TEXT = "TestFiles" + File.separator + "AAL.txt";
+	static final String AAL_TEMPLATE = "TestFiles" + File.separator + "AAL.template.txt";
+	static final String AFL_3_TEXT = "TestFiles" + File.separator + "AFL-3.0.txt";
+	static final String AFL_3_TEMPLATE = "TestFiles" + File.separator + "AFL-3.0.template.txt";
+	static final String BSDNETBSD_TEXT = "TestFiles" + File.separator + "BSD-2-Clause-NetBSD.txt";
+	static final String BSDNETBSD_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause-NetBSD.template.txt";
+	static final String APACHE_1_0_TEXT = "TestFiles" + File.separator + "Apache-1.0.txt";
+	static final String APACHE_1_0_TEMPLATE = "TestFiles" + File.separator + "Apache-1.0.template.txt";
+	static final String BSD_2_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-2-Clause.txt";
+	static final String BSD_2_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause.template.txt";
+	static final String BSD_4_CLAUSE_UC_TEXT  = "TestFiles" + File.separator + "BSD-4-Clause-UC.txt";
+	static final String BSD_4_CLAUSE_UC_TEMPLATE  = "TestFiles" + File.separator + "BSD-4-Clause-UC.template.txt";
+	static final String BSD_4_CLAUSE_TEXT  = "TestFiles" + File.separator + "BSD-4-Clause.txt";
+	static final String BSD_4_CLAUSE_TEMPLATE  = "TestFiles" + File.separator + "BSD-4-Clause.template.txt";
+	static final String CROSSWORD_TEXT  = "TestFiles" + File.separator + "Crossword.txt";
+	static final String CROSSWORD_TEMPLATE  = "TestFiles" + File.separator + "Crossword.template.txt";
+	static final String DFSL_TEXT = "TestFiles" + File.separator + "D-FSL-1.0.txt";
+	static final String DFSL_TEMPLATE = "TestFiles" + File.separator + "D-FSL-1.0.template.txt";
+	static final String CONDOR_1_1_TEXT = "TestFiles" + File.separator + "Condor-1.1.txt";
+	static final String CONDOR_1_1_TEMPLATE = "TestFiles" + File.separator + "Condor-1.1.template.txt";
+	static final String ISC_TEXT = "TestFiles" + File.separator + "ISC.txt";
+	static final String ISC_TEMPLATE = "TestFiles" + File.separator + "ISC.template.txt";
+	static final String MPL_1_TEXT = "TestFiles" + File.separator + "MPL-1.0.txt";
+	static final String MPL_1_TEMPLATE = "TestFiles" + File.separator + "MPL-1.0.template.txt";
+	static final String RPSL_1_TEXT = "TestFiles" + File.separator + "RPSL-1.0.txt";
+	static final String RPSL_1_TEMPLATE = "TestFiles" + File.separator + "RPSL-1.0.template.txt";
+	static final String RSCPL_TEXT = "TestFiles" + File.separator + "RSCPL.txt";
+	static final String RSCPL_TEMPLATE = "TestFiles" + File.separator + "RSCPL.template.txt";
+	static final String HPND_TEXT = "TestFiles" + File.separator + "HPND.txt";
+	static final String HPND_TEMPLATE = "TestFiles" + File.separator + "HPND.template.txt";
+	static final String CECILL2_TEXT = "TestFiles" + File.separator + "CECILL-2.0.txt";
+	static final String CECILL2_TEMPLATE = "TestFiles" + File.separator + "CECILL-2.0.template.txt";
+	static final String BSD_1_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-1-Clause.txt";
+	static final String BSD_1_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-1-Clause.template.txt";
+	static final String LPPL_1_3_A_TEXT = "TestFiles" + File.separator + "LPPL-1.3a.txt";
+	static final String LPPL_1_3_A_TEMPLATE = "TestFiles" + File.separator + "LPPL-1.3a.template.txt";
+	static final String LPPL_1_3_C_TEXT = "TestFiles" + File.separator + "LPPL-1.3c.txt";
+	static final String LPPL_1_3_C_TEMPLATE = "TestFiles" + File.separator + "LPPL-1.3c.template.txt";
+	static final String ODBL_1_TEXT = "TestFiles" + File.separator + "ODbL-1.0.txt";
+	static final String ODBL_1_TEMPLATE = "TestFiles" + File.separator + "ODbL-1.0.template.txt";
+	static final String SLEEPYCAT_TEXT = "TestFiles" + File.separator + "Sleepycat.txt";
+	static final String SLEEPYCAT_TEMPLATE = "TestFiles" + File.separator + "Sleepycat.template.txt";
+	static final String SSPL_1_0_TEXT = "TestFiles" + File.separator + "SSPL-1.0.txt";
+	static final String SSPL_1_0_TEMPLATE = "TestFiles" + File.separator + "SSPL-1.0.template.txt";
+	static final String AGPL_3_0_ONLY_TEXT = "TestFiles" + File.separator + "AGPL-3.0-only.txt";
+	static final String AGPL_3_0_ONLY_TEMPLATE = "TestFiles" + File.separator + "AGPL-3.0-only.template.txt";
+	static final String BSD_PROTECTION_TEXT = "TestFiles" + File.separator + "BSD-Protection.txt";
+	static final String BSD_PROTECTION_TEMPLATE = "TestFiles" + File.separator + "BSD-Protection.template.txt";
+	static final String BSD_2_CLAUSE_VIEW_TEXT = "TestFiles" + File.separator + "BSD-2-Clause-Views.txt";
+	static final String BSD_2_CLAUSE_VIEW_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause-Views.template.txt";
+	static final String EUPL_1_2_TEXT = "TestFiles" + File.separator + "EUPL-1.2.txt";
+	static final String EUPL_1_2_TEMPLATE = "TestFiles" + File.separator + "EUPL-1.2.template.txt";
+	static final String GD_TEXT = "TestFiles" + File.separator + "GD.txt";
+	static final String GD_TEMPLATE = "TestFiles" + File.separator + "GD.template.txt";
+	
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+	}
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+	}
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @Before
-    public void setUp() throws Exception {
-    }
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-    }
+	/**
+	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#CompareTemplateOutputHandler(java.lang.String)}.
+	 * @throws Exception
+	 */
+	@Test
+	public void testCompareTemplateOutputHandler() throws Exception {
+		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler("test");
+		ctoh.completeParsing();
+		assertTrue(ctoh.matches());
+	}
 
-    /**
-     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#CompareTemplateOutputHandler(java.lang.String)}.
-     * @throws Exception
-     */
-    @Test
-    public void testCompareTemplateOutputHandler() throws Exception {
-        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler("test");
-        ctoh.completeParsing();
-        assertTrue(ctoh.matches());
-    }
+	/**
+	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
+	 * @throws LicenseTemplateRuleException
+	 */
+	@Test
+	public void testOptionalText()  throws Exception {
+		String l1 = "Line 1\n";
+		String l2 = "Line 2\n";
+		String l3 = "Line 3\n";
+		String l4 = "Line 4";
+		// optional in middle
+		String compareText = l1+l4;
+		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.text(l1);
+		ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
+		ctoh.text(l2);
+		ctoh.text(l3);
+		ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
+		ctoh.text(l4);
+		ctoh.completeParsing();
+		assertTrue(ctoh.matches());
 
-    /**
-     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
-     * @throws LicenseTemplateRuleException
-     */
-    @Test
-    public void testOptionalText()  throws Exception {
-        String l1 = "Line 1\n";
-        String l2 = "Line 2\n";
-        String l3 = "Line 3\n";
-        String l4 = "Line 4";
-        // optional in middle
-        String compareText = l1+l4;
-        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.text(l1);
-        ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
-        ctoh.text(l2);
-        ctoh.text(l3);
-        ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
-        ctoh.text(l4);
-        ctoh.completeParsing();
-        assertTrue(ctoh.matches());
+		// optional at beginning
+		compareText = l3+l4;
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
+		ctoh.text(l1);
+		ctoh.text(l2);
+		ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
+		ctoh.text(l3);
+		ctoh.text(l4);
+		ctoh.completeParsing();
+		assertTrue(ctoh.matches());
+		// optional at end
+		compareText = l1+l2+l3;
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.text(l1);
+		ctoh.text(l2);
+		ctoh.text(l3);
+		ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
+		ctoh.text(l4);
+		ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
+		ctoh.completeParsing();
+		assertTrue(ctoh.matches());
+		// optional code present
+		compareText = l1+l2+l3+l4;
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.text(l1);
+		ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
+		ctoh.text(l2);
+		ctoh.text(l3);
+		ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
+		ctoh.text(l4);
+		ctoh.completeParsing();
+		assertTrue(ctoh.matches());
+	}
 
-        // optional at beginning
-        compareText = l3+l4;
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
-        ctoh.text(l1);
-        ctoh.text(l2);
-        ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
-        ctoh.text(l3);
-        ctoh.text(l4);
-        ctoh.completeParsing();
-        assertTrue(ctoh.matches());
-        // optional at end
-        compareText = l1+l2+l3;
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.text(l1);
-        ctoh.text(l2);
-        ctoh.text(l3);
-        ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
-        ctoh.text(l4);
-        ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
-        ctoh.completeParsing();
-        assertTrue(ctoh.matches());
-        // optional code present
-        compareText = l1+l2+l3+l4;
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.text(l1);
-        ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
-        ctoh.text(l2);
-        ctoh.text(l3);
-        ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
-        ctoh.text(l4);
-        ctoh.completeParsing();
-        assertTrue(ctoh.matches());
-    }
+	/**
+	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#textEquivalent(java.lang.String)}.
+	 */
+	@Test
+	public void testTextEquivalent() throws Exception {
+		String l1 = "Line 1 with // skippable ## /** stuff\n";
+		String l1S = "Line 1 with skippable stuff\n";
+		String l2 = "## Line 2 with replaceable analogue cancelled stuff\n";
+		String l2S = "Line 2 with replaceable analogue cancelled stuff\n";
+		String l2R = "## Line 2 with replaceable analog canceled stuff\n";
+		String l3 = "Line\n";
+		String l4 = "Line 4";
+		String compareText = l1+l2+l3+l4;
+		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
+		int nextToken = ctoh.textEquivalent(l1,0);
+		assertTrue(nextToken > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l2,nextToken)) > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
+		// after end of compare string
+		assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) < 0);
 
-    /**
-     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#textEquivalent(java.lang.String)}.
-     */
-    @Test
-    public void testTextEquivalent() throws Exception {
-        String l1 = "Line 1 with // skippable ## /** stuff\n";
-        String l1S = "Line 1 with skippable stuff\n";
-        String l2 = "## Line 2 with replaceable analogue cancelled stuff\n";
-        String l2S = "Line 2 with replaceable analogue cancelled stuff\n";
-        String l2R = "## Line 2 with replaceable analog canceled stuff\n";
-        String l3 = "Line\n";
-        String l4 = "Line 4";
-        String compareText = l1+l2+l3+l4;
-        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-        int nextToken = ctoh.textEquivalent(l1,0);
-        assertTrue(nextToken > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l2,nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
-        // after end of compare string
-        assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) < 0);
+		// difference in string
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		assertTrue((nextToken = ctoh.textEquivalent(l4,0)) < 0);
 
-        // difference in string
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        assertTrue((nextToken = ctoh.textEquivalent(l4,0)) < 0);
+		// skippable tokens
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		assertTrue((nextToken = ctoh.textEquivalent(l1S,0)) > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l2S,nextToken)) > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
 
-        // skippable tokens
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        assertTrue((nextToken = ctoh.textEquivalent(l1S,0)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l2S,nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
+		// equivalent tokens
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		assertTrue((nextToken = ctoh.textEquivalent(l1,0)) > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l2R,nextToken)) > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
+		assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
+	}
 
-        // equivalent tokens
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        assertTrue((nextToken = ctoh.textEquivalent(l1,0)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l2R,nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
-        assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
-    }
+	/**
+	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
+	 */
+	@Test
+	public void testNormalText() throws Exception {
+		String line1 = "this is line one\n";
+		String line2 = "this line 2 is another line\n";
+		String line3 = "yet another third line\n";
+		String compareText = line1 + line2 + line3;
+		// success scenario
+		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.text(line1);
+		ctoh.text(line2);
+		ctoh.text(line3);
+		ctoh.completeParsing();
+		assertTrue(ctoh.matches());
 
-    /**
-     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
-     */
-    @Test
-    public void testNormalText() throws Exception {
-        String line1 = "this is line one\n";
-        String line2 = "this line 2 is another line\n";
-        String line3 = "yet another third line\n";
-        String compareText = line1 + line2 + line3;
-        // success scenario
-        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.text(line1);
-        ctoh.text(line2);
-        ctoh.text(line3);
-        ctoh.completeParsing();
-        assertTrue(ctoh.matches());
+		// missmatched line
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.text(line1);
+		ctoh.text("wait - this doesn't match");
+		ctoh.text(line3);
+		ctoh.completeParsing();
+		assertTrue(!ctoh.matches());
 
-        // missmatched line
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.text(line1);
-        ctoh.text("wait - this doesn't match");
-        ctoh.text(line3);
-        ctoh.completeParsing();
-        assertTrue(!ctoh.matches());
+		// off the end of the compare text
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.text(line1);
+		ctoh.text(line2);
+		ctoh.text(line3);
+		ctoh.text("more off the end");
+		ctoh.completeParsing();
+		assertTrue(!ctoh.matches());
+	}
 
-        // off the end of the compare text
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.text(line1);
-        ctoh.text(line2);
-        ctoh.text(line3);
-        ctoh.text("more off the end");
-        ctoh.completeParsing();
-        assertTrue(!ctoh.matches());
-    }
+	/**
+	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#variableRule(org.spdx.licenseTemplate.LicenseTemplateRule)}.
+	 * @throws LicenseTemplateRuleException
+	 */
+	@Test
+	public void testVariableRule()  throws Exception {
+		String line1 = "this is line one\n";
+		String line2 = "this line 2 is another line\n";
+		String line2Match = "this\\sline\\s.+another\\sline";
+		String line2MissMatch = "this\\sline\\s.+oops\\sline";
+		String line2PartialMatch = "this\\sline\\s.+another";
+		String line3 = "yet another third line\n";
+		String compareText = line1 + line2 + line3;
+		// success scenario
+		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.text(line1);
+		LicenseTemplateRule variableRule = new LicenseTemplateRule("Variable Rule",
+								RuleType.VARIABLE, line2, line2Match, "Example: "+line2);
+		ctoh.variableRule(variableRule);
+		ctoh.text(line3);
+		ctoh.completeParsing();
+		assertTrue(ctoh.matches());
 
-    /**
-     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#variableRule(org.spdx.licenseTemplate.LicenseTemplateRule)}.
-     * @throws LicenseTemplateRuleException
-     */
-    @Test
-    public void testVariableRule()  throws Exception {
-        String line1 = "this is line one\n";
-        String line2 = "this line 2 is another line\n";
-        String line2Match = "this\\sline\\s.+another\\sline";
-        String line2MissMatch = "this\\sline\\s.+oops\\sline";
-        String line2PartialMatch = "this\\sline\\s.+another";
-        String line3 = "yet another third line\n";
-        String compareText = line1 + line2 + line3;
-        // success scenario
-        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.text(line1);
-        LicenseTemplateRule variableRule = new LicenseTemplateRule("Variable Rule",
-                RuleType.VARIABLE, line2, line2Match, "Example: "+line2);
-        ctoh.variableRule(variableRule);
-        ctoh.text(line3);
-        ctoh.completeParsing();
-        assertTrue(ctoh.matches());
+		// success scenario - match at end
+		String partialCompareText = line1 + line2;
+		ctoh = new CompareTemplateOutputHandler(partialCompareText);
+		ctoh.text(line1);
+		variableRule = new LicenseTemplateRule("Variable Rule",
+								RuleType.VARIABLE, line2, line2Match, "Example: "+line2);
+		ctoh.variableRule(variableRule);
+		ctoh.completeParsing();
+		assertTrue(ctoh.matches());
 
-        // success scenario - match at end
-        String partialCompareText = line1 + line2;
-        ctoh = new CompareTemplateOutputHandler(partialCompareText);
-        ctoh.text(line1);
-        variableRule = new LicenseTemplateRule("Variable Rule",
-                RuleType.VARIABLE, line2, line2Match, "Example: "+line2);
-        ctoh.variableRule(variableRule);
-        ctoh.completeParsing();
-        assertTrue(ctoh.matches());
+		// non-matching
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		ctoh.text(line1);
+		variableRule = new LicenseTemplateRule("Variable Rule",
+				RuleType.VARIABLE, line2, line2MissMatch, "Example: "+line2);
+		ctoh.variableRule(variableRule);
+		ctoh.text(line3);
+		ctoh.completeParsing();
+		assertTrue(!ctoh.matches());
 
-        // non-matching
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        ctoh.text(line1);
-        variableRule = new LicenseTemplateRule("Variable Rule",
-                RuleType.VARIABLE, line2, line2MissMatch, "Example: "+line2);
-        ctoh.variableRule(variableRule);
-        ctoh.text(line3);
-        ctoh.completeParsing();
-        assertTrue(!ctoh.matches());
+		// Extra word
+		ctoh = new CompareTemplateOutputHandler(compareText);
+		variableRule = new LicenseTemplateRule("Variable Rule",
+				RuleType.VARIABLE, line2, line2PartialMatch, "Example: "+line2);
+		ctoh.variableRule(variableRule);
+		ctoh.text(line3);
+		ctoh.completeParsing();
+		assertTrue(!ctoh.matches());
+	}
 
-        // Extra word
-        ctoh = new CompareTemplateOutputHandler(compareText);
-        variableRule = new LicenseTemplateRule("Variable Rule",
-                RuleType.VARIABLE, line2, line2PartialMatch, "Example: "+line2);
-        ctoh.variableRule(variableRule);
-        ctoh.text(line3);
-        ctoh.completeParsing();
-        assertTrue(!ctoh.matches());
-    }
+	@Test
+	public void testRegressionAdobeGlyph() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(ADOBE_GLYPH_TEXT);
+		String templateText = UnitTestHelper.fileToText(ADOBE_GLYPH_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		assertTrue(templateOutputHandler.matches());
+	}
 
-    @Test
-    public void testRegressionAdobeGlyph() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(ADOBE_GLYPH_TEXT);
-        String templateText = UnitTestHelper.fileToText(ADOBE_GLYPH_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        assertTrue(templateOutputHandler.matches());
-    }
+	@Test
+	public void testRegressionAFL3() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(AFL_3_TEXT);
+		String templateText = UnitTestHelper.fileToText(AFL_3_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		assertTrue(templateOutputHandler.matches());
+	}
 
-    @Test
-    public void testRegressionAFL3() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(AFL_3_TEXT);
-        String templateText = UnitTestHelper.fileToText(AFL_3_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        assertTrue(templateOutputHandler.matches());
-    }
+	@Test
+	public void testRegressionBsdNetBsd() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(BSDNETBSD_TEXT);
+		String templateText = UnitTestHelper.fileToText(BSDNETBSD_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionBsdNetBsd() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(BSDNETBSD_TEXT);
-        String templateText = UnitTestHelper.fileToText(BSDNETBSD_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionApache1() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(APACHE_1_0_TEXT);
+		String templateText = UnitTestHelper.fileToText(APACHE_1_0_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionApache1() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(APACHE_1_0_TEXT);
-        String templateText = UnitTestHelper.fileToText(APACHE_1_0_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionBsd2Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(BSD_2_CLAUSE_TEXT);
+		String templateText = UnitTestHelper.fileToText(BSD_2_CLAUSE_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionBsd2Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(BSD_2_CLAUSE_TEXT);
-        String templateText = UnitTestHelper.fileToText(BSD_2_CLAUSE_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionBsd4ClauseUC() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(BSD_4_CLAUSE_UC_TEXT);
+		String templateText = UnitTestHelper.fileToText(BSD_4_CLAUSE_UC_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionBsd4ClauseUC() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(BSD_4_CLAUSE_UC_TEXT);
-        String templateText = UnitTestHelper.fileToText(BSD_4_CLAUSE_UC_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionBsd4Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(BSD_4_CLAUSE_TEXT);
+		String templateText = UnitTestHelper.fileToText(BSD_4_CLAUSE_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionBsd4Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(BSD_4_CLAUSE_TEXT);
-        String templateText = UnitTestHelper.fileToText(BSD_4_CLAUSE_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionCrossword() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(CROSSWORD_TEXT);
+		String templateText = UnitTestHelper.fileToText(CROSSWORD_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionCrossword() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(CROSSWORD_TEXT);
-        String templateText = UnitTestHelper.fileToText(CROSSWORD_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionDFSL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(DFSL_TEXT);
+		String templateText = UnitTestHelper.fileToText(DFSL_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionDFSL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(DFSL_TEXT);
-        String templateText = UnitTestHelper.fileToText(DFSL_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionCondor11() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(CONDOR_1_1_TEXT);
+		String templateText = UnitTestHelper.fileToText(CONDOR_1_1_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionCondor11() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(CONDOR_1_1_TEXT);
-        String templateText = UnitTestHelper.fileToText(CONDOR_1_1_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionIsc() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(ISC_TEXT);
+		String templateText = UnitTestHelper.fileToText(ISC_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionIsc() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(ISC_TEXT);
-        String templateText = UnitTestHelper.fileToText(ISC_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionMPL11() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(MPL_1_TEXT);
+		String templateText = UnitTestHelper.fileToText(MPL_1_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionMPL11() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(MPL_1_TEXT);
-        String templateText = UnitTestHelper.fileToText(MPL_1_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionRPSL1() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(RPSL_1_TEXT);
+		String templateText = UnitTestHelper.fileToText(RPSL_1_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionRPSL1() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(RPSL_1_TEXT);
-        String templateText = UnitTestHelper.fileToText(RPSL_1_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionRSCPL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(RSCPL_TEXT);
+		String templateText = UnitTestHelper.fileToText(RSCPL_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionRSCPL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(RSCPL_TEXT);
-        String templateText = UnitTestHelper.fileToText(RSCPL_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionAAL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(AAL_TEXT);
+		String templateText = UnitTestHelper.fileToText(AAL_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionAAL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(AAL_TEXT);
-        String templateText = UnitTestHelper.fileToText(AAL_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionHPND() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(HPND_TEXT);
+		String templateText = UnitTestHelper.fileToText(HPND_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionHPND() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(HPND_TEXT);
-        String templateText = UnitTestHelper.fileToText(HPND_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionCECILL2() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(CECILL2_TEXT);
+		String templateText = UnitTestHelper.fileToText(CECILL2_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionCECILL2() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(CECILL2_TEXT);
-        String templateText = UnitTestHelper.fileToText(CECILL2_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionBSD1Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(BSD_1_CLAUSE_TEXT);
+		String templateText = UnitTestHelper.fileToText(BSD_1_CLAUSE_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionBSD1Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(BSD_1_CLAUSE_TEXT);
-        String templateText = UnitTestHelper.fileToText(BSD_1_CLAUSE_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionLppl13a() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(LPPL_1_3_A_TEXT);
+		String templateText = UnitTestHelper.fileToText(LPPL_1_3_A_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionLppl13a() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(LPPL_1_3_A_TEXT);
-        String templateText = UnitTestHelper.fileToText(LPPL_1_3_A_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionLppl13c() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(LPPL_1_3_C_TEXT);
+		String templateText = UnitTestHelper.fileToText(LPPL_1_3_C_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionLppl13c() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(LPPL_1_3_C_TEXT);
-        String templateText = UnitTestHelper.fileToText(LPPL_1_3_C_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionOdbl() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(ODBL_1_TEXT);
+		String templateText = UnitTestHelper.fileToText(ODBL_1_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionOdbl() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(ODBL_1_TEXT);
-        String templateText = UnitTestHelper.fileToText(ODBL_1_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionSleepycat() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(SLEEPYCAT_TEXT);
+		String templateText = UnitTestHelper.fileToText(SLEEPYCAT_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionSleepycat() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(SLEEPYCAT_TEXT);
-        String templateText = UnitTestHelper.fileToText(SLEEPYCAT_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+	@Test
+	public void testRegressionSSPL10() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(SSPL_1_0_TEXT);
+		String templateText = UnitTestHelper.fileToText(SSPL_1_0_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
-    @Test
-    public void testRegressionSSPL10() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(SSPL_1_0_TEXT);
-        String templateText = UnitTestHelper.fileToText(SSPL_1_0_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
-
-    @Test
+   @Test
     public void testRegressionBSDProtection() throws IOException, LicenseTemplateRuleException, LicenseParserException {
         String compareText = UnitTestHelper.fileToText(BSD_PROTECTION_TEXT);
         String templateText = UnitTestHelper.fileToText(BSD_PROTECTION_TEMPLATE);
@@ -582,50 +582,50 @@ public class TestCompareTemplateOutputHandler {
             fail(templateOutputHandler.getDifferences().getDifferenceMessage());
         }
     }
-
-    @Test
-    public void testRegressionBSDView() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(BSD_2_CLAUSE_VIEW_TEXT);
-        String templateText = UnitTestHelper.fileToText(BSD_2_CLAUSE_VIEW_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
-
-    @Test
-    public void testRegressionEUPL12() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(EUPL_1_2_TEXT);
-        String templateText = UnitTestHelper.fileToText(EUPL_1_2_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
-
-    @Test
-    public void testRegressionGD() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(GD_TEXT);
-        String templateText = UnitTestHelper.fileToText(GD_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
-
-    @Test
-    public void testCompareHttps() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-        String compareText = UnitTestHelper.fileToText(AGPL_3_0_ONLY_TEXT);
-        String templateText = UnitTestHelper.fileToText(AGPL_3_0_ONLY_TEMPLATE);
-        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-        if (!templateOutputHandler.matches()) {
-            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-        }
-    }
+   
+   @Test
+   public void testRegressionBSDView() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+       String compareText = UnitTestHelper.fileToText(BSD_2_CLAUSE_VIEW_TEXT);
+       String templateText = UnitTestHelper.fileToText(BSD_2_CLAUSE_VIEW_TEMPLATE);
+       CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+       SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+       if (!templateOutputHandler.matches()) {
+           fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+       }
+   }
+   
+   @Test
+   public void testRegressionEUPL12() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+       String compareText = UnitTestHelper.fileToText(EUPL_1_2_TEXT);
+       String templateText = UnitTestHelper.fileToText(EUPL_1_2_TEMPLATE);
+       CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+       SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+       if (!templateOutputHandler.matches()) {
+           fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+       }
+   }
+   
+   @Test
+   public void testRegressionGD() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+       String compareText = UnitTestHelper.fileToText(GD_TEXT);
+       String templateText = UnitTestHelper.fileToText(GD_TEMPLATE);
+       CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+       SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+       if (!templateOutputHandler.matches()) {
+           fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+       }
+   }
+   
+	@Test
+	public void testCompareHttps() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+		String compareText = UnitTestHelper.fileToText(AGPL_3_0_ONLY_TEXT);
+		String templateText = UnitTestHelper.fileToText(AGPL_3_0_ONLY_TEMPLATE);
+		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+		if (!templateOutputHandler.matches()) {
+			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+		}
+	}
 
     // Test for literal string matching without any var's
     @Test

--- a/src/test/java/org/spdx/utility/compare/TestCompareTemplateOutputHandler.java
+++ b/src/test/java/org/spdx/utility/compare/TestCompareTemplateOutputHandler.java
@@ -27,10 +27,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.spdx.licenseTemplate.LicenseParserException;
-import org.spdx.licenseTemplate.LicenseTemplateRule;
-import org.spdx.licenseTemplate.LicenseTemplateRuleException;
-import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
+import org.spdx.licenseTemplate.*;
 import org.spdx.licenseTemplate.LicenseTemplateRule.RuleType;
 
 /**
@@ -40,538 +37,541 @@ import org.spdx.licenseTemplate.LicenseTemplateRule.RuleType;
  */
 public class TestCompareTemplateOutputHandler {
 
-	static final String ADOBE_GLYPH_TEXT = "TestFiles" + File.separator + "Adobe-Glyph.txt";
-	static final String ADOBE_GLYPH_TEMPLATE = "TestFiles" + File.separator + "Adobe-Glyph.template.txt";
-	static final String AAL_TEXT = "TestFiles" + File.separator + "AAL.txt";
-	static final String AAL_TEMPLATE = "TestFiles" + File.separator + "AAL.template.txt";
-	static final String AFL_3_TEXT = "TestFiles" + File.separator + "AFL-3.0.txt";
-	static final String AFL_3_TEMPLATE = "TestFiles" + File.separator + "AFL-3.0.template.txt";
-	static final String BSDNETBSD_TEXT = "TestFiles" + File.separator + "BSD-2-Clause-NetBSD.txt";
-	static final String BSDNETBSD_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause-NetBSD.template.txt";
-	static final String APACHE_1_0_TEXT = "TestFiles" + File.separator + "Apache-1.0.txt";
-	static final String APACHE_1_0_TEMPLATE = "TestFiles" + File.separator + "Apache-1.0.template.txt";
-	static final String BSD_2_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-2-Clause.txt";
-	static final String BSD_2_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause.template.txt";
-	static final String BSD_4_CLAUSE_UC_TEXT  = "TestFiles" + File.separator + "BSD-4-Clause-UC.txt";
-	static final String BSD_4_CLAUSE_UC_TEMPLATE  = "TestFiles" + File.separator + "BSD-4-Clause-UC.template.txt";
-	static final String BSD_4_CLAUSE_TEXT  = "TestFiles" + File.separator + "BSD-4-Clause.txt";
-	static final String BSD_4_CLAUSE_TEMPLATE  = "TestFiles" + File.separator + "BSD-4-Clause.template.txt";
-	static final String CROSSWORD_TEXT  = "TestFiles" + File.separator + "Crossword.txt";
-	static final String CROSSWORD_TEMPLATE  = "TestFiles" + File.separator + "Crossword.template.txt";
-	static final String DFSL_TEXT = "TestFiles" + File.separator + "D-FSL-1.0.txt";
-	static final String DFSL_TEMPLATE = "TestFiles" + File.separator + "D-FSL-1.0.template.txt";
-	static final String CONDOR_1_1_TEXT = "TestFiles" + File.separator + "Condor-1.1.txt";
-	static final String CONDOR_1_1_TEMPLATE = "TestFiles" + File.separator + "Condor-1.1.template.txt";
-	static final String ISC_TEXT = "TestFiles" + File.separator + "ISC.txt";
-	static final String ISC_TEMPLATE = "TestFiles" + File.separator + "ISC.template.txt";
-	static final String MPL_1_TEXT = "TestFiles" + File.separator + "MPL-1.0.txt";
-	static final String MPL_1_TEMPLATE = "TestFiles" + File.separator + "MPL-1.0.template.txt";
-	static final String RPSL_1_TEXT = "TestFiles" + File.separator + "RPSL-1.0.txt";
-	static final String RPSL_1_TEMPLATE = "TestFiles" + File.separator + "RPSL-1.0.template.txt";
-	static final String RSCPL_TEXT = "TestFiles" + File.separator + "RSCPL.txt";
-	static final String RSCPL_TEMPLATE = "TestFiles" + File.separator + "RSCPL.template.txt";
-	static final String HPND_TEXT = "TestFiles" + File.separator + "HPND.txt";
-	static final String HPND_TEMPLATE = "TestFiles" + File.separator + "HPND.template.txt";
-	static final String CECILL2_TEXT = "TestFiles" + File.separator + "CECILL-2.0.txt";
-	static final String CECILL2_TEMPLATE = "TestFiles" + File.separator + "CECILL-2.0.template.txt";
-	static final String BSD_1_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-1-Clause.txt";
-	static final String BSD_1_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-1-Clause.template.txt";
-	static final String LPPL_1_3_A_TEXT = "TestFiles" + File.separator + "LPPL-1.3a.txt";
-	static final String LPPL_1_3_A_TEMPLATE = "TestFiles" + File.separator + "LPPL-1.3a.template.txt";
-	static final String LPPL_1_3_C_TEXT = "TestFiles" + File.separator + "LPPL-1.3c.txt";
-	static final String LPPL_1_3_C_TEMPLATE = "TestFiles" + File.separator + "LPPL-1.3c.template.txt";
-	static final String ODBL_1_TEXT = "TestFiles" + File.separator + "ODbL-1.0.txt";
-	static final String ODBL_1_TEMPLATE = "TestFiles" + File.separator + "ODbL-1.0.template.txt";
-	static final String SLEEPYCAT_TEXT = "TestFiles" + File.separator + "Sleepycat.txt";
-	static final String SLEEPYCAT_TEMPLATE = "TestFiles" + File.separator + "Sleepycat.template.txt";
-	static final String SSPL_1_0_TEXT = "TestFiles" + File.separator + "SSPL-1.0.txt";
-	static final String SSPL_1_0_TEMPLATE = "TestFiles" + File.separator + "SSPL-1.0.template.txt";
-	static final String AGPL_3_0_ONLY_TEXT = "TestFiles" + File.separator + "AGPL-3.0-only.txt";
-	static final String AGPL_3_0_ONLY_TEMPLATE = "TestFiles" + File.separator + "AGPL-3.0-only.template.txt";
-	static final String BSD_PROTECTION_TEXT = "TestFiles" + File.separator + "BSD-Protection.txt";
-	static final String BSD_PROTECTION_TEMPLATE = "TestFiles" + File.separator + "BSD-Protection.template.txt";
-	static final String BSD_2_CLAUSE_VIEW_TEXT = "TestFiles" + File.separator + "BSD-2-Clause-Views.txt";
-	static final String BSD_2_CLAUSE_VIEW_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause-Views.template.txt";
-	static final String EUPL_1_2_TEXT = "TestFiles" + File.separator + "EUPL-1.2.txt";
-	static final String EUPL_1_2_TEMPLATE = "TestFiles" + File.separator + "EUPL-1.2.template.txt";
-	static final String GD_TEXT = "TestFiles" + File.separator + "GD.txt";
-	static final String GD_TEMPLATE = "TestFiles" + File.separator + "GD.template.txt";
-	
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-	}
+    static final String ADOBE_GLYPH_TEXT = "TestFiles" + File.separator + "Adobe-Glyph.txt";
+    static final String ADOBE_GLYPH_TEMPLATE = "TestFiles" + File.separator + "Adobe-Glyph.template.txt";
+    static final String AAL_TEXT = "TestFiles" + File.separator + "AAL.txt";
+    static final String AAL_TEMPLATE = "TestFiles" + File.separator + "AAL.template.txt";
+    static final String AFL_3_TEXT = "TestFiles" + File.separator + "AFL-3.0.txt";
+    static final String AFL_3_TEMPLATE = "TestFiles" + File.separator + "AFL-3.0.template.txt";
+    static final String BSDNETBSD_TEXT = "TestFiles" + File.separator + "BSD-2-Clause-NetBSD.txt";
+    static final String BSDNETBSD_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause-NetBSD.template.txt";
+    static final String APACHE_1_0_TEXT = "TestFiles" + File.separator + "Apache-1.0.txt";
+    static final String APACHE_1_0_TEMPLATE = "TestFiles" + File.separator + "Apache-1.0.template.txt";
+    static final String BSD_2_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-2-Clause.txt";
+    static final String BSD_2_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause.template.txt";
+    static final String BSD_4_CLAUSE_UC_TEXT = "TestFiles" + File.separator + "BSD-4-Clause-UC.txt";
+    static final String BSD_4_CLAUSE_UC_TEMPLATE = "TestFiles" + File.separator + "BSD-4-Clause-UC.template.txt";
+    static final String BSD_4_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-4-Clause.txt";
+    static final String BSD_4_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-4-Clause.template.txt";
+    static final String CROSSWORD_TEXT = "TestFiles" + File.separator + "Crossword.txt";
+    static final String CROSSWORD_TEMPLATE = "TestFiles" + File.separator + "Crossword.template.txt";
+    static final String DFSL_TEXT = "TestFiles" + File.separator + "D-FSL-1.0.txt";
+    static final String DFSL_TEMPLATE = "TestFiles" + File.separator + "D-FSL-1.0.template.txt";
+    static final String CONDOR_1_1_TEXT = "TestFiles" + File.separator + "Condor-1.1.txt";
+    static final String CONDOR_1_1_TEMPLATE = "TestFiles" + File.separator + "Condor-1.1.template.txt";
+    static final String ISC_TEXT = "TestFiles" + File.separator + "ISC.txt";
+    static final String ISC_TEMPLATE = "TestFiles" + File.separator + "ISC.template.txt";
+    static final String MPL_1_TEXT = "TestFiles" + File.separator + "MPL-1.0.txt";
+    static final String MPL_1_TEMPLATE = "TestFiles" + File.separator + "MPL-1.0.template.txt";
+    static final String RPSL_1_TEXT = "TestFiles" + File.separator + "RPSL-1.0.txt";
+    static final String RPSL_1_TEMPLATE = "TestFiles" + File.separator + "RPSL-1.0.template.txt";
+    static final String RSCPL_TEXT = "TestFiles" + File.separator + "RSCPL.txt";
+    static final String RSCPL_TEMPLATE = "TestFiles" + File.separator + "RSCPL.template.txt";
+    static final String HPND_TEXT = "TestFiles" + File.separator + "HPND.txt";
+    static final String HPND_TEMPLATE = "TestFiles" + File.separator + "HPND.template.txt";
+    static final String CECILL2_TEXT = "TestFiles" + File.separator + "CECILL-2.0.txt";
+    static final String CECILL2_TEMPLATE = "TestFiles" + File.separator + "CECILL-2.0.template.txt";
+    static final String BSD_1_CLAUSE_TEXT = "TestFiles" + File.separator + "BSD-1-Clause.txt";
+    static final String BSD_1_CLAUSE_TEMPLATE = "TestFiles" + File.separator + "BSD-1-Clause.template.txt";
+    static final String LPPL_1_3_A_TEXT = "TestFiles" + File.separator + "LPPL-1.3a.txt";
+    static final String LPPL_1_3_A_TEMPLATE = "TestFiles" + File.separator + "LPPL-1.3a.template.txt";
+    static final String LPPL_1_3_C_TEXT = "TestFiles" + File.separator + "LPPL-1.3c.txt";
+    static final String LPPL_1_3_C_TEMPLATE = "TestFiles" + File.separator + "LPPL-1.3c.template.txt";
+    static final String ODBL_1_TEXT = "TestFiles" + File.separator + "ODbL-1.0.txt";
+    static final String ODBL_1_TEMPLATE = "TestFiles" + File.separator + "ODbL-1.0.template.txt";
+    static final String SLEEPYCAT_TEXT = "TestFiles" + File.separator + "Sleepycat.txt";
+    static final String SLEEPYCAT_TEMPLATE = "TestFiles" + File.separator + "Sleepycat.template.txt";
+    static final String SSPL_1_0_TEXT = "TestFiles" + File.separator + "SSPL-1.0.txt";
+    static final String SSPL_1_0_TEMPLATE = "TestFiles" + File.separator + "SSPL-1.0.template.txt";
+    static final String AGPL_3_0_ONLY_TEXT = "TestFiles" + File.separator + "AGPL-3.0-only.txt";
+    static final String AGPL_3_0_ONLY_TEMPLATE = "TestFiles" + File.separator + "AGPL-3.0-only.template.txt";
+    static final String BSD_PROTECTION_TEXT = "TestFiles" + File.separator + "BSD-Protection.txt";
+    static final String BSD_PROTECTION_TEMPLATE = "TestFiles" + File.separator + "BSD-Protection.template.txt";
+    static final String BSD_2_CLAUSE_VIEW_TEXT = "TestFiles" + File.separator + "BSD-2-Clause-Views.txt";
+    static final String BSD_2_CLAUSE_VIEW_TEMPLATE = "TestFiles" + File.separator + "BSD-2-Clause-Views.template.txt";
+    static final String EUPL_1_2_TEXT = "TestFiles" + File.separator + "EUPL-1.2.txt";
+    static final String EUPL_1_2_TEMPLATE = "TestFiles" + File.separator + "EUPL-1.2.template.txt";
+    static final String GD_TEXT = "TestFiles" + File.separator + "GD.txt";
+    static final String GD_TEMPLATE = "TestFiles" + File.separator + "GD.template.txt";
 
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
-	}
+    /**
+     * @throws java.lang.Exception
+     */
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
 
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@Before
-	public void setUp() throws Exception {
-	}
+    /**
+     * @throws java.lang.Exception
+     */
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
 
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@After
-	public void tearDown() throws Exception {
-	}
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+    }
 
-	/**
-	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#CompareTemplateOutputHandler(java.lang.String)}.
-	 * @throws Exception
-	 */
-	@Test
-	public void testCompareTemplateOutputHandler() throws Exception {
-		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler("test");
-		ctoh.completeParsing();
-		assertTrue(ctoh.matches());
-	}
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+    }
 
-	/**
-	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
-	 * @throws LicenseTemplateRuleException
-	 */
-	@Test
-	public void testOptionalText()  throws Exception {
-		String l1 = "Line 1\n";
-		String l2 = "Line 2\n";
-		String l3 = "Line 3\n";
-		String l4 = "Line 4";
-		// optional in middle
-		String compareText = l1+l4;
-		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.text(l1);
-		ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
-		ctoh.text(l2);
-		ctoh.text(l3);
-		ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
-		ctoh.text(l4);
-		ctoh.completeParsing();
-		assertTrue(ctoh.matches());
+    /**
+     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#CompareTemplateOutputHandler(java.lang.String)}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCompareTemplateOutputHandler() throws Exception {
+        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler("test");
+        ctoh.completeParsing();
+        assertTrue(ctoh.matches());
+    }
 
-		// optional at beginning
-		compareText = l3+l4;
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
-		ctoh.text(l1);
-		ctoh.text(l2);
-		ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
-		ctoh.text(l3);
-		ctoh.text(l4);
-		ctoh.completeParsing();
-		assertTrue(ctoh.matches());
-		// optional at end
-		compareText = l1+l2+l3;
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.text(l1);
-		ctoh.text(l2);
-		ctoh.text(l3);
-		ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
-		ctoh.text(l4);
-		ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
-		ctoh.completeParsing();
-		assertTrue(ctoh.matches());
-		// optional code present
-		compareText = l1+l2+l3+l4;
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.text(l1);
-		ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
-		ctoh.text(l2);
-		ctoh.text(l3);
-		ctoh.endOptional(new LicenseTemplateRule("EndOptional",RuleType.END_OPTIONAL));
-		ctoh.text(l4);
-		ctoh.completeParsing();
-		assertTrue(ctoh.matches());
-	}
+    /**
+     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
+     *
+     * @throws LicenseTemplateRuleException
+     */
+    @Test
+    public void testOptionalText() throws Exception {
+        String l1 = "Line 1\n";
+        String l2 = "Line 2\n";
+        String l3 = "Line 3\n";
+        String l4 = "Line 4";
+        // optional in middle
+        String compareText = l1 + l4;
+        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.text(l1);
+        ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
+        ctoh.text(l2);
+        ctoh.text(l3);
+        ctoh.endOptional(new LicenseTemplateRule("EndOptional", RuleType.END_OPTIONAL));
+        ctoh.text(l4);
+        ctoh.completeParsing();
+        assertTrue(ctoh.matches());
 
-	/**
-	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#textEquivalent(java.lang.String)}.
-	 */
-	@Test
-	public void testTextEquivalent() throws Exception {
-		String l1 = "Line 1 with // skippable ## /** stuff\n";
-		String l1S = "Line 1 with skippable stuff\n";
-		String l2 = "## Line 2 with replaceable analogue cancelled stuff\n";
-		String l2S = "Line 2 with replaceable analogue cancelled stuff\n";
-		String l2R = "## Line 2 with replaceable analog canceled stuff\n";
-		String l3 = "Line\n";
-		String l4 = "Line 4";
-		String compareText = l1+l2+l3+l4;
-		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-		int nextToken = ctoh.textEquivalent(l1,0);
-		assertTrue(nextToken > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l2,nextToken)) > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
-		// after end of compare string
-		assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) < 0);
+        // optional at beginning
+        compareText = l3 + l4;
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
+        ctoh.text(l1);
+        ctoh.text(l2);
+        ctoh.endOptional(new LicenseTemplateRule("EndOptional", RuleType.END_OPTIONAL));
+        ctoh.text(l3);
+        ctoh.text(l4);
+        ctoh.completeParsing();
+        assertTrue(ctoh.matches());
+        // optional at end
+        compareText = l1 + l2 + l3;
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.text(l1);
+        ctoh.text(l2);
+        ctoh.text(l3);
+        ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
+        ctoh.text(l4);
+        ctoh.endOptional(new LicenseTemplateRule("EndOptional", RuleType.END_OPTIONAL));
+        ctoh.completeParsing();
+        assertTrue(ctoh.matches());
+        // optional code present
+        compareText = l1 + l2 + l3 + l4;
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.text(l1);
+        ctoh.beginOptional(new LicenseTemplateRule("OptionalRule", RuleType.BEGIN_OPTIONAL));
+        ctoh.text(l2);
+        ctoh.text(l3);
+        ctoh.endOptional(new LicenseTemplateRule("EndOptional", RuleType.END_OPTIONAL));
+        ctoh.text(l4);
+        ctoh.completeParsing();
+        assertTrue(ctoh.matches());
+    }
 
-		// difference in string
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		assertTrue((nextToken = ctoh.textEquivalent(l4,0)) < 0);
+    /**
+     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#textEquivalent(java.lang.String)}.
+     */
+    @Test
+    public void testTextEquivalent() throws Exception {
+        String l1 = "Line 1 with // skippable ## /** stuff\n";
+        String l1S = "Line 1 with skippable stuff\n";
+        String l2 = "## Line 2 with replaceable analogue cancelled stuff\n";
+        String l2S = "Line 2 with replaceable analogue cancelled stuff\n";
+        String l2R = "## Line 2 with replaceable analog canceled stuff\n";
+        String l3 = "Line\n";
+        String l4 = "Line 4";
+        String compareText = l1 + l2 + l3 + l4;
+        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
+        int nextToken = ctoh.textEquivalent(l1, 0);
+        assertTrue(nextToken > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l2, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l3, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l4, nextToken)) > 0);
+        // after end of compare string
+        assertTrue((nextToken = ctoh.textEquivalent(l4, nextToken)) < 0);
 
-		// skippable tokens
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		assertTrue((nextToken = ctoh.textEquivalent(l1S,0)) > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l2S,nextToken)) > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
+        // difference in string
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        assertTrue((nextToken = ctoh.textEquivalent(l4, 0)) < 0);
 
-		// equivalent tokens
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		assertTrue((nextToken = ctoh.textEquivalent(l1,0)) > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l2R,nextToken)) > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l3,nextToken)) > 0);
-		assertTrue((nextToken = ctoh.textEquivalent(l4,nextToken)) > 0);
-	}
+        // skippable tokens
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        assertTrue((nextToken = ctoh.textEquivalent(l1S, 0)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l2S, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l3, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l4, nextToken)) > 0);
 
-	/**
-	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
-	 */
-	@Test
-	public void testNormalText() throws Exception {
-		String line1 = "this is line one\n";
-		String line2 = "this line 2 is another line\n";
-		String line3 = "yet another third line\n";
-		String compareText = line1 + line2 + line3;
-		// success scenario
-		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.text(line1);
-		ctoh.text(line2);
-		ctoh.text(line3);
-		ctoh.completeParsing();
-		assertTrue(ctoh.matches());
+        // equivalent tokens
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        assertTrue((nextToken = ctoh.textEquivalent(l1, 0)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l2R, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l3, nextToken)) > 0);
+        assertTrue((nextToken = ctoh.textEquivalent(l4, nextToken)) > 0);
+    }
 
-		// missmatched line
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.text(line1);
-		ctoh.text("wait - this doesn't match");
-		ctoh.text(line3);
-		ctoh.completeParsing();
-		assertTrue(!ctoh.matches());
+    /**
+     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#text(java.lang.String)}.
+     */
+    @Test
+    public void testNormalText() throws Exception {
+        String line1 = "this is line one\n";
+        String line2 = "this line 2 is another line\n";
+        String line3 = "yet another third line\n";
+        String compareText = line1 + line2 + line3;
+        // success scenario
+        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.text(line1);
+        ctoh.text(line2);
+        ctoh.text(line3);
+        ctoh.completeParsing();
+        assertTrue(ctoh.matches());
 
-		// off the end of the compare text
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.text(line1);
-		ctoh.text(line2);
-		ctoh.text(line3);
-		ctoh.text("more off the end");
-		ctoh.completeParsing();
-		assertTrue(!ctoh.matches());
-	}
+        // missmatched line
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.text(line1);
+        ctoh.text("wait - this doesn't match");
+        ctoh.text(line3);
+        ctoh.completeParsing();
+        assertTrue(!ctoh.matches());
 
-	/**
-	 * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#variableRule(org.spdx.licenseTemplate.LicenseTemplateRule)}.
-	 * @throws LicenseTemplateRuleException
-	 */
-	@Test
-	public void testVariableRule()  throws Exception {
-		String line1 = "this is line one\n";
-		String line2 = "this line 2 is another line\n";
-		String line2Match = "this\\sline\\s.+another\\sline";
-		String line2MissMatch = "this\\sline\\s.+oops\\sline";
-		String line2PartialMatch = "this\\sline\\s.+another";
-		String line3 = "yet another third line\n";
-		String compareText = line1 + line2 + line3;
-		// success scenario
-		CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.text(line1);
-		LicenseTemplateRule variableRule = new LicenseTemplateRule("Variable Rule",
-								RuleType.VARIABLE, line2, line2Match, "Example: "+line2);
-		ctoh.variableRule(variableRule);
-		ctoh.text(line3);
-		ctoh.completeParsing();
-		assertTrue(ctoh.matches());
+        // off the end of the compare text
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.text(line1);
+        ctoh.text(line2);
+        ctoh.text(line3);
+        ctoh.text("more off the end");
+        ctoh.completeParsing();
+        assertTrue(!ctoh.matches());
+    }
 
-		// success scenario - match at end
-		String partialCompareText = line1 + line2;
-		ctoh = new CompareTemplateOutputHandler(partialCompareText);
-		ctoh.text(line1);
-		variableRule = new LicenseTemplateRule("Variable Rule",
-								RuleType.VARIABLE, line2, line2Match, "Example: "+line2);
-		ctoh.variableRule(variableRule);
-		ctoh.completeParsing();
-		assertTrue(ctoh.matches());
+    /**
+     * Test method for {@link org.spdx.compare.CompareTemplateOutputHandler#variableRule(org.spdx.licenseTemplate.LicenseTemplateRule)}.
+     *
+     * @throws LicenseTemplateRuleException
+     */
+    @Test
+    public void testVariableRule() throws Exception {
+        String line1 = "this is line one\n";
+        String line2 = "this line 2 is another line\n";
+        String line2Match = "this\\sline\\s.+another\\sline";
+        String line2MissMatch = "this\\sline\\s.+oops\\sline";
+        String line2PartialMatch = "this\\sline\\s.+another";
+        String line3 = "yet another third line\n";
+        String compareText = line1 + line2 + line3;
+        // success scenario
+        CompareTemplateOutputHandler ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.text(line1);
+        LicenseTemplateRule variableRule = new LicenseTemplateRule("Variable Rule",
+                RuleType.VARIABLE, line2, line2Match, "Example: " + line2);
+        ctoh.variableRule(variableRule);
+        ctoh.text(line3);
+        ctoh.completeParsing();
+        assertTrue(ctoh.matches());
 
-		// non-matching
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		ctoh.text(line1);
-		variableRule = new LicenseTemplateRule("Variable Rule",
-				RuleType.VARIABLE, line2, line2MissMatch, "Example: "+line2);
-		ctoh.variableRule(variableRule);
-		ctoh.text(line3);
-		ctoh.completeParsing();
-		assertTrue(!ctoh.matches());
+        // success scenario - match at end
+        String partialCompareText = line1 + line2;
+        ctoh = new CompareTemplateOutputHandler(partialCompareText);
+        ctoh.text(line1);
+        variableRule = new LicenseTemplateRule("Variable Rule",
+                RuleType.VARIABLE, line2, line2Match, "Example: " + line2);
+        ctoh.variableRule(variableRule);
+        ctoh.completeParsing();
+        assertTrue(ctoh.matches());
 
-		// Extra word
-		ctoh = new CompareTemplateOutputHandler(compareText);
-		variableRule = new LicenseTemplateRule("Variable Rule",
-				RuleType.VARIABLE, line2, line2PartialMatch, "Example: "+line2);
-		ctoh.variableRule(variableRule);
-		ctoh.text(line3);
-		ctoh.completeParsing();
-		assertTrue(!ctoh.matches());
-	}
+        // non-matching
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        ctoh.text(line1);
+        variableRule = new LicenseTemplateRule("Variable Rule",
+                RuleType.VARIABLE, line2, line2MissMatch, "Example: " + line2);
+        ctoh.variableRule(variableRule);
+        ctoh.text(line3);
+        ctoh.completeParsing();
+        assertTrue(!ctoh.matches());
 
-	@Test
-	public void testRegressionAdobeGlyph() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(ADOBE_GLYPH_TEXT);
-		String templateText = UnitTestHelper.fileToText(ADOBE_GLYPH_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		assertTrue(templateOutputHandler.matches());
-	}
+        // Extra word
+        ctoh = new CompareTemplateOutputHandler(compareText);
+        variableRule = new LicenseTemplateRule("Variable Rule",
+                RuleType.VARIABLE, line2, line2PartialMatch, "Example: " + line2);
+        ctoh.variableRule(variableRule);
+        ctoh.text(line3);
+        ctoh.completeParsing();
+        assertTrue(!ctoh.matches());
+    }
 
-	@Test
-	public void testRegressionAFL3() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(AFL_3_TEXT);
-		String templateText = UnitTestHelper.fileToText(AFL_3_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		assertTrue(templateOutputHandler.matches());
-	}
+    @Test
+    public void testRegressionAdobeGlyph() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(ADOBE_GLYPH_TEXT);
+        String templateText = UnitTestHelper.fileToText(ADOBE_GLYPH_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        assertTrue(templateOutputHandler.matches());
+    }
 
-	@Test
-	public void testRegressionBsdNetBsd() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(BSDNETBSD_TEXT);
-		String templateText = UnitTestHelper.fileToText(BSDNETBSD_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionAFL3() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(AFL_3_TEXT);
+        String templateText = UnitTestHelper.fileToText(AFL_3_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        assertTrue(templateOutputHandler.matches());
+    }
 
-	@Test
-	public void testRegressionApache1() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(APACHE_1_0_TEXT);
-		String templateText = UnitTestHelper.fileToText(APACHE_1_0_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionBsdNetBsd() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(BSDNETBSD_TEXT);
+        String templateText = UnitTestHelper.fileToText(BSDNETBSD_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionBsd2Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(BSD_2_CLAUSE_TEXT);
-		String templateText = UnitTestHelper.fileToText(BSD_2_CLAUSE_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionApache1() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(APACHE_1_0_TEXT);
+        String templateText = UnitTestHelper.fileToText(APACHE_1_0_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionBsd4ClauseUC() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(BSD_4_CLAUSE_UC_TEXT);
-		String templateText = UnitTestHelper.fileToText(BSD_4_CLAUSE_UC_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionBsd2Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(BSD_2_CLAUSE_TEXT);
+        String templateText = UnitTestHelper.fileToText(BSD_2_CLAUSE_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionBsd4Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(BSD_4_CLAUSE_TEXT);
-		String templateText = UnitTestHelper.fileToText(BSD_4_CLAUSE_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionBsd4ClauseUC() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(BSD_4_CLAUSE_UC_TEXT);
+        String templateText = UnitTestHelper.fileToText(BSD_4_CLAUSE_UC_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionCrossword() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(CROSSWORD_TEXT);
-		String templateText = UnitTestHelper.fileToText(CROSSWORD_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionBsd4Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(BSD_4_CLAUSE_TEXT);
+        String templateText = UnitTestHelper.fileToText(BSD_4_CLAUSE_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionDFSL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(DFSL_TEXT);
-		String templateText = UnitTestHelper.fileToText(DFSL_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionCrossword() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(CROSSWORD_TEXT);
+        String templateText = UnitTestHelper.fileToText(CROSSWORD_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionCondor11() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(CONDOR_1_1_TEXT);
-		String templateText = UnitTestHelper.fileToText(CONDOR_1_1_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionDFSL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(DFSL_TEXT);
+        String templateText = UnitTestHelper.fileToText(DFSL_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionIsc() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(ISC_TEXT);
-		String templateText = UnitTestHelper.fileToText(ISC_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionCondor11() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(CONDOR_1_1_TEXT);
+        String templateText = UnitTestHelper.fileToText(CONDOR_1_1_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionMPL11() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(MPL_1_TEXT);
-		String templateText = UnitTestHelper.fileToText(MPL_1_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionIsc() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(ISC_TEXT);
+        String templateText = UnitTestHelper.fileToText(ISC_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionRPSL1() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(RPSL_1_TEXT);
-		String templateText = UnitTestHelper.fileToText(RPSL_1_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionMPL11() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(MPL_1_TEXT);
+        String templateText = UnitTestHelper.fileToText(MPL_1_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionRSCPL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(RSCPL_TEXT);
-		String templateText = UnitTestHelper.fileToText(RSCPL_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionRPSL1() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(RPSL_1_TEXT);
+        String templateText = UnitTestHelper.fileToText(RPSL_1_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionAAL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(AAL_TEXT);
-		String templateText = UnitTestHelper.fileToText(AAL_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionRSCPL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(RSCPL_TEXT);
+        String templateText = UnitTestHelper.fileToText(RSCPL_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionHPND() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(HPND_TEXT);
-		String templateText = UnitTestHelper.fileToText(HPND_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionAAL() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(AAL_TEXT);
+        String templateText = UnitTestHelper.fileToText(AAL_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionCECILL2() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(CECILL2_TEXT);
-		String templateText = UnitTestHelper.fileToText(CECILL2_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionHPND() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(HPND_TEXT);
+        String templateText = UnitTestHelper.fileToText(HPND_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionBSD1Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(BSD_1_CLAUSE_TEXT);
-		String templateText = UnitTestHelper.fileToText(BSD_1_CLAUSE_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionCECILL2() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(CECILL2_TEXT);
+        String templateText = UnitTestHelper.fileToText(CECILL2_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionLppl13a() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(LPPL_1_3_A_TEXT);
-		String templateText = UnitTestHelper.fileToText(LPPL_1_3_A_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionBSD1Clause() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(BSD_1_CLAUSE_TEXT);
+        String templateText = UnitTestHelper.fileToText(BSD_1_CLAUSE_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionLppl13c() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(LPPL_1_3_C_TEXT);
-		String templateText = UnitTestHelper.fileToText(LPPL_1_3_C_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionLppl13a() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(LPPL_1_3_A_TEXT);
+        String templateText = UnitTestHelper.fileToText(LPPL_1_3_A_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionOdbl() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(ODBL_1_TEXT);
-		String templateText = UnitTestHelper.fileToText(ODBL_1_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionLppl13c() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(LPPL_1_3_C_TEXT);
+        String templateText = UnitTestHelper.fileToText(LPPL_1_3_C_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionSleepycat() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(SLEEPYCAT_TEXT);
-		String templateText = UnitTestHelper.fileToText(SLEEPYCAT_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionOdbl() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(ODBL_1_TEXT);
+        String templateText = UnitTestHelper.fileToText(ODBL_1_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-	@Test
-	public void testRegressionSSPL10() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(SSPL_1_0_TEXT);
-		String templateText = UnitTestHelper.fileToText(SSPL_1_0_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+    @Test
+    public void testRegressionSleepycat() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(SLEEPYCAT_TEXT);
+        String templateText = UnitTestHelper.fileToText(SLEEPYCAT_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
 
-   @Test
+    @Test
+    public void testRegressionSSPL10() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(SSPL_1_0_TEXT);
+        String templateText = UnitTestHelper.fileToText(SSPL_1_0_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
+
+    @Test
     public void testRegressionBSDProtection() throws IOException, LicenseTemplateRuleException, LicenseParserException {
         String compareText = UnitTestHelper.fileToText(BSD_PROTECTION_TEXT);
         String templateText = UnitTestHelper.fileToText(BSD_PROTECTION_TEMPLATE);
@@ -581,48 +581,95 @@ public class TestCompareTemplateOutputHandler {
             fail(templateOutputHandler.getDifferences().getDifferenceMessage());
         }
     }
-   
-   @Test
-   public void testRegressionBSDView() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-       String compareText = UnitTestHelper.fileToText(BSD_2_CLAUSE_VIEW_TEXT);
-       String templateText = UnitTestHelper.fileToText(BSD_2_CLAUSE_VIEW_TEMPLATE);
-       CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-       SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-       if (!templateOutputHandler.matches()) {
-           fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-       }
-   }
-   
-   @Test
-   public void testRegressionEUPL12() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-       String compareText = UnitTestHelper.fileToText(EUPL_1_2_TEXT);
-       String templateText = UnitTestHelper.fileToText(EUPL_1_2_TEMPLATE);
-       CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-       SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-       if (!templateOutputHandler.matches()) {
-           fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-       }
-   }
-   
-   @Test
-   public void testRegressionGD() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-       String compareText = UnitTestHelper.fileToText(GD_TEXT);
-       String templateText = UnitTestHelper.fileToText(GD_TEMPLATE);
-       CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-       SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-       if (!templateOutputHandler.matches()) {
-           fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-       }
-   }
-   
-	@Test
-	public void testCompareHttps() throws IOException, LicenseTemplateRuleException, LicenseParserException {
-		String compareText = UnitTestHelper.fileToText(AGPL_3_0_ONLY_TEXT);
-		String templateText = UnitTestHelper.fileToText(AGPL_3_0_ONLY_TEMPLATE);
-		CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
-		SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
-		if (!templateOutputHandler.matches()) {
-			fail(templateOutputHandler.getDifferences().getDifferenceMessage());
-		}
-	}
+
+    @Test
+    public void testRegressionBSDView() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(BSD_2_CLAUSE_VIEW_TEXT);
+        String templateText = UnitTestHelper.fileToText(BSD_2_CLAUSE_VIEW_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
+
+    @Test
+    public void testRegressionEUPL12() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(EUPL_1_2_TEXT);
+        String templateText = UnitTestHelper.fileToText(EUPL_1_2_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
+
+    @Test
+    public void testRegressionGD() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(GD_TEXT);
+        String templateText = UnitTestHelper.fileToText(GD_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
+
+    @Test
+    public void testCompareHttps() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String compareText = UnitTestHelper.fileToText(AGPL_3_0_ONLY_TEXT);
+        String templateText = UnitTestHelper.fileToText(AGPL_3_0_ONLY_TEMPLATE);
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        if (!templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+    }
+
+    // Test for literal string matching without any var's
+    @Test
+    public void testCompareAlphabetDiffMessage() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String templateText = "a b c d e f g h i j k l m n o p q r s t u v w x y z";
+        String compareText = "a b\tc d e f g h i j k l m n o p\nq r s t u v w x y zebra";
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+
+        System.out.println(templateOutputHandler.getDifferences().getDifferenceMessage());
+
+        if (templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+        assertEquals(String.format("Normal text of license does not match starting at line #2 column #18 \"zebra\" when comparing to template text \"%s\"", templateText), templateOutputHandler.getDifferences().getDifferenceMessage());
+        assertEquals(1, templateOutputHandler.getDifferences().getDifferences().size());
+        LineColumn lineColumn = templateOutputHandler.getDifferences().getDifferences().get(0);
+        assertEquals(2, lineColumn.getLine());
+        assertEquals(18, lineColumn.getColumn());
+        assertEquals(5, lineColumn.getLen());
+
+        String line = compareText.split("\n")[lineColumn.getLine() - 1];
+        String failedToken = line.substring(lineColumn.getColumn(), lineColumn.getColumn() + lineColumn.getLen());
+        assertEquals("zebra", failedToken);
+    }
+
+    @Test
+    public void testCompareAlphabetVarDiffMessage() throws IOException, LicenseTemplateRuleException, LicenseParserException {
+        String templateText = "a<<var;name=\"more\";original=\"\";match=\"[b-y\\s]*\">><<beginOptional>>z<<endOptional>>";
+        String compareText = "a b\tc d e f g h i j k l m n o p\nq r s t u v w x y z end";
+        CompareTemplateOutputHandler templateOutputHandler = new CompareTemplateOutputHandler(compareText);
+        SpdxLicenseTemplateHelper.parseTemplate(templateText, templateOutputHandler);
+        System.out.println(templateOutputHandler.getDifferences().getDifferenceMessage());
+        if (templateOutputHandler.matches()) {
+            fail(templateOutputHandler.getDifferences().getDifferenceMessage());
+        }
+        assertEquals("Additional text found after the end of the expected license text starting at line #2 column #20 \"end\"", templateOutputHandler.getDifferences().getDifferenceMessage());
+        assertEquals(1, templateOutputHandler.getDifferences().getDifferences().size());
+        LineColumn lineColumn = templateOutputHandler.getDifferences().getDifferences().get(0);
+        assertEquals(2, lineColumn.getLine());
+        assertEquals(20, lineColumn.getColumn());
+        assertEquals(3, lineColumn.getLen());
+
+        String line = compareText.split("\n")[lineColumn.getLine() - 1];
+        String failedToken = line.substring(lineColumn.getColumn(), lineColumn.getColumn() + lineColumn.getLen());
+        assertEquals("end", failedToken);
+    }
 }


### PR DESCRIPTION
Current impl reports the failed index on the next token or null if already at last token.
This minor fix corrects the errorLocation based on the token matching incrementing index before failing
Added two test cases to validate with pure text abd var template matches.