### PR TITLE
Prototype improvements to compare performance

### DIFF
--- a/src/main/java/org/spdx/utility/compare/SpdxItemComparer.java
+++ b/src/main/java/org/spdx/utility/compare/SpdxItemComparer.java
@@ -80,9 +80,16 @@ public class SpdxItemComparer {
 	 */
 	protected Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap;
 
-	
+	protected Map<Integer, Boolean> equivalentElements;
+
 	public SpdxItemComparer(Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap) {
+		this(extractedLicenseIdMap, new HashMap<>());
+	}
+	
+	public SpdxItemComparer(Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap,
+							Map<Integer, Boolean> equivalentElements) {
 		this.extractedLicenseIdMap = extractedLicenseIdMap;
+		this.equivalentElements = equivalentElements;
 	}
 	
 	/**
@@ -191,13 +198,14 @@ public class SpdxItemComparer {
         for (Entry<SpdxDocument, SpdxItem> entry : this.documentItem.entrySet()) {
             Map<SpdxDocument, List<Relationship>> uniqueCompareRelationship = this.uniqueRelationships.computeIfAbsent(entry.getKey(), k -> new HashMap<>());
             Collection<Relationship> compareRelationships = entry.getValue().getRelationships();
-            List<Relationship> uniqueRelationships = SpdxComparer.findUniqueRelationships(relationships, compareRelationships);
+            List<Relationship> uniqueRelationships = SpdxComparer.findUniqueRelationships(relationships,
+					compareRelationships, equivalentElements);
             if (!uniqueRelationships.isEmpty()) {
                 this.relationshipsEquals = false;
                 this.itemDifferenceFound = true;
             }
             uniqueDocRelationship.put(entry.getKey(), uniqueRelationships);
-            uniqueRelationships = SpdxComparer.findUniqueRelationships(compareRelationships, relationships);
+            uniqueRelationships = SpdxComparer.findUniqueRelationships(compareRelationships, relationships, equivalentElements);
             if (!uniqueRelationships.isEmpty()) {
                 this.relationshipsEquals = false;
                 this.itemDifferenceFound = true;

--- a/src/test/java/org/spdx/utility/compare/SpdxComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxComparerTest.java
@@ -649,12 +649,6 @@ public class SpdxComparerTest extends TestCase {
 		return retval;
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#compare(org.spdx.rdfparser.SpdxDocument, org.spdx.rdfparser.SpdxDocument)}.
-	 * @throws InvalidSPDXAnalysisException 
-	 * @throws IOException 
-	 * @throws SpdxCompareException 
-	 */
 	public void testCompare() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -671,13 +665,6 @@ public class SpdxComparerTest extends TestCase {
 		assertEquals(doc2.hashCode(), comparer.getSpdxDoc(1).hashCode());
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#compareLicense(int, org.spdx.rdfparser.license.AnyLicenseInfo, int, org.spdx.rdfparser.license.AnyLicenseInfo)}.
-	 * @throws InvalidSPDXAnalysisException 
-	 * @throws IOException 
-	 * @throws SpdxCompareException 
-	 * @throws InvalidLicenseStringException 
-	 */
 	public void testCompareLicense() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException, InvalidLicenseStringException {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -949,12 +936,6 @@ public class SpdxComparerTest extends TestCase {
 		}
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#isDifferenceFound()}.
-	 * @throws InvalidSPDXAnalysisException 
-	 * @throws IOException 
-	 * @throws SpdxCompareException 
-	 */
 	public void testIsDifferenceFound() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -970,12 +951,6 @@ public class SpdxComparerTest extends TestCase {
 
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#isSpdxVersionEqual()}.
-	 * @throws InvalidSPDXAnalysisException 
-	 * @throws SpdxCompareException 
-	 * @throws IOException 
-	 */
 	public void testIsSpdxVersionEqual() throws InvalidSPDXAnalysisException, SpdxCompareException, IOException {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -993,12 +968,6 @@ public class SpdxComparerTest extends TestCase {
 		assertFalse(comparer.isDifferenceFound());
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#getSpdxDoc(int)}.
-	 * @throws InvalidSPDXAnalysisException 
-	 * @throws IOException 
-	 * @throws SpdxCompareException 
-	 */
 	public void testGetSpdxDoc() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -1013,12 +982,6 @@ public class SpdxComparerTest extends TestCase {
 
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#isDataLicenseEqual()}.
-	 * @throws InvalidSPDXAnalysisException 
-	 * @throws IOException 
-	 * @throws SpdxCompareException 
-	 */
 	public void testIsDataLicenseEqual() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException {
 		SpdxComparer comparer = new SpdxComparer();		
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -1035,9 +998,6 @@ public class SpdxComparerTest extends TestCase {
 		assertFalse(comparer.isDataLicenseEqual());
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#isDocumentCommentsEqual()}.
-	 */
 	public void testIsDocumentCommentsEqual()throws IOException, InvalidSPDXAnalysisException, SpdxCompareException {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -1055,10 +1015,6 @@ public class SpdxComparerTest extends TestCase {
 		assertFalse(comparer.isDifferenceFound());
 		assertTrue(comparer.isDocumentCommentsEqual());
 	}
-
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#isExtractedLicensingInfosEqual()}.
-	 */
 	public void testIsExtractedLicensingInfosEqual() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException  {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -1275,9 +1231,6 @@ public class SpdxComparerTest extends TestCase {
 		assertTrue(comparer.isDifferenceFound());		
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#getUniqueExtractedLicenses(int, int)}.
-	 */
 	public void testGetUniqueExtractedLicenses() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException  {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -1423,9 +1376,6 @@ public class SpdxComparerTest extends TestCase {
 		assertTrue(uniqueLicIds.contains(result.get(3).getLicenseId()));
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#getExtractedLicenseDifferences(int, int)}.
-	 */
 	public void testGetExtractedLicenseDifferences() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException  {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -1667,9 +1617,6 @@ public class SpdxComparerTest extends TestCase {
 		return crossReff1.containsAll(collection);
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#isPackageEqual()}.
-	 */
 	public void testIsPackageEqual() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException  {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -1685,9 +1632,6 @@ public class SpdxComparerTest extends TestCase {
 		// note - other test cases will test to make sure isPackageEquals is set for all changes where it should be false
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#isCreatorInformationEqual()}.
-	 */
 	public void testIsCreatorInformationEqual() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException  {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -1745,9 +1689,6 @@ public class SpdxComparerTest extends TestCase {
 		assertTrue(comparer.isDifferenceFound());
 	}
 
-	/**
-	 * Test method for {@link org.spdx.compare.SpdxComparer#getUniqueCreators(int, int)}.
-	 */
 	public void testGetUniqueCreators() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException  {
 		SpdxComparer comparer = new SpdxComparer();
 		SpdxDocument doc1 = createTestSpdxDoc(DOC_URIA);
@@ -2056,10 +1997,10 @@ public class SpdxComparerTest extends TestCase {
 		Optional<SpdxElement> element1B = Optional.of(e1b);
 		Optional<SpdxElement> none1 = Optional.empty();
 		Optional<SpdxElement> none2 = Optional.empty();
-		assertTrue(SpdxComparer.elementsEquivalent(element1A, element2A));
-		assertFalse(SpdxComparer.elementsEquivalent(element1A, element1B));
-		assertFalse(SpdxComparer.elementsEquivalent(element1A, none1));
-		assertTrue(SpdxComparer.elementsEquivalent(none1, none2));
+		assertTrue(SpdxComparer.elementsEquivalent(element1A, element2A, new HashMap<>()));
+		assertFalse(SpdxComparer.elementsEquivalent(element1A, element1B, new HashMap<>()));
+		assertFalse(SpdxComparer.elementsEquivalent(element1A, none1, new HashMap<>()));
+		assertTrue(SpdxComparer.elementsEquivalent(none1, none2, new HashMap<>()));
 	}
 
 	public void testFindUniqueChecksums() throws InvalidSPDXAnalysisException {

--- a/src/test/java/org/spdx/utility/compare/SpdxItemComparerTest.java
+++ b/src/test/java/org/spdx/utility/compare/SpdxItemComparerTest.java
@@ -201,7 +201,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertFalse(comparer.isDifferenceFound());
@@ -249,7 +249,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSEB2, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -269,7 +269,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, new AnyLicenseInfo[] {LICENSEB1}, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -291,7 +291,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, s2, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -312,7 +312,7 @@ public class SpdxItemComparerTest extends TestCase {
 		itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertEquals(0, comparer.getUniqueSeenLicenses(DOCB, DOCA).size());
@@ -328,7 +328,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB =createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, s2, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -349,7 +349,7 @@ public class SpdxItemComparerTest extends TestCase {
 		itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertEquals(0, comparer.getUniqueSeenLicenses(DOCA, DOCB).size());
@@ -362,7 +362,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTB, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -382,7 +382,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTB, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -402,7 +402,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTB);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -423,7 +423,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTB,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -443,7 +443,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTB, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertEquals(itemA, comparer.getItem(DOCA));
@@ -459,7 +459,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, r2,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -481,7 +481,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, r2,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -501,7 +501,7 @@ public class SpdxItemComparerTest extends TestCase {
 		itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertEquals(0, comparer.getUniqueRelationship(DOCA, DOCB).size());
@@ -517,7 +517,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, r2,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);;
 		assertTrue(comparer.isDifferenceFound());
@@ -537,7 +537,7 @@ public class SpdxItemComparerTest extends TestCase {
 		itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertEquals(0, comparer.getUniqueRelationship(DOCB, DOCA).size());
@@ -553,7 +553,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, a2, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -575,7 +575,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, a2, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -595,7 +595,7 @@ public class SpdxItemComparerTest extends TestCase {
 		itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertEquals(0, comparer.getUniqueAnnotations(DOCA, DOCB).size());
@@ -611,7 +611,7 @@ public class SpdxItemComparerTest extends TestCase {
 		SpdxItem itemB = createGenericItem(DOCB, NAMEA, COMMENTA, a2, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		SpdxItemComparer comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertTrue(comparer.isDifferenceFound());
@@ -631,7 +631,7 @@ public class SpdxItemComparerTest extends TestCase {
 		itemB = createGenericItem(DOCB, NAMEA, COMMENTA, ANNOTATIONSA, RELATIONSHIPSA,
 				LICENSE_CONCLUDEDB, LICENSE_INFO_FROM_FILESB, COPYRIGHTA, LICENSE_COMMENTA,
 				ATTRIBUTION_TEXTA);
-		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP);
+		comparer = new SpdxItemComparer(LICENSE_XLATION_MAP, new HashMap<>());
 		comparer.addDocumentItem(DOCA, itemA);
 		comparer.addDocumentItem(DOCB, itemB);
 		assertEquals(0, comparer.getUniqueAnnotations(DOCB, DOCA).size());


### PR DESCRIPTION
This is a prototype of changes to improve the performance of compares. This commit is a partial implementation of a map that keeps track of elements which are equivalent.  Unfortunately, this creates a memory problem with large compares, so more work needs to be done.