### PR TITLE
Check null to avoid null pointer exception

### DIFF
--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -123,12 +123,15 @@ public class LicenseCompareHelper {
 	}
 
 	/**
-	 * Locate the original text starting with the start token and ending with the end token
+	 * Locate the original text starting with the start token and ending with the
+	 * end token
+	 *
 	 * @param fullLicenseText entire license text
-	 * @param startToken starting token
-	 * @param endToken ending token
+	 * @param startToken      starting token
+	 * @param endToken        ending token
 	 * @param tokenToLocation token location
-	 * @return original text starting with the start token and ending with the end token
+	 * @return original text starting with the start token and ending with the end
+	 *         token
 	 */
 	public static String locateOriginalText(String fullLicenseText, int startToken, int endToken,  
 			Map<Integer, LineColumn> tokenToLocation, String[] tokens) {
@@ -224,39 +227,35 @@ public class LicenseCompareHelper {
 	/**
 	 * Check whether the given text contains only a single token
 	 * <p>
-	 * A single token string is defined as a non-null string that does not
-	 * contain any newline characters and contains exactly one non-empty token
-	 * as identified by the {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
+	 * A single token string is a string that contains zero or one token as
+	 * identified by the {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
 	 * </p>
 	 *
 	 * @param text The text to test.
-	 * @return {@code true} if the text contains a single token,
+	 * @return {@code true} if the text contains zero one token,
 	 *         {@code false} otherwise.
 	 */
 	public static boolean isSingleTokenString(@Nullable String text) {
 		if (text == null || text.isEmpty()) {
-			return false;
-		}
-		if (text.contains("\n")) {
-			return false;
+			return true; // zero tokens is considered a single token string
 		}
 		Matcher m = LicenseTextHelper.TOKEN_SPLIT_PATTERN.matcher(text);
-		boolean found = false;
+		int nonWhitespaceTokenCount = 0;
 		while (m.find()) {
 			if (!m.group(1).trim().isEmpty()) {
-				if (found) {
-					return false;
-				} else {
-					found = true;
+				nonWhitespaceTokenCount++;
+				if (nonWhitespaceTokenCount > 1) {
+					return false; // more than one token
 				}
 			}
 		}
-		return found;
+		return true; // either no tokens or one token
 	}
 
 	/**
 	 * Compares two licenses from potentially two different documents which may have
 	 * different license ID's for the same license
+	 *
 	 * @param license1 first license to compare
 	 * @param license2 second license to compare
 	 * @param xlationMap Mapping the license ID's from license 1 to license 2
@@ -367,11 +366,15 @@ public class LicenseCompareHelper {
 	}
 	
 	/**
-	 * @param template Template in the standard template format used for comparison
+	 * Compare the provided text against a license template using SPDX matching
+	 * guidelines
+	 *
+	 * @param template    Template in the standard template format used for
+	 *                    comparison
 	 * @param compareText Text to compare using the template
-	 * @return any differences found
+	 * @return Any differences found
 	 * @throws SpdxCompareException on comparison errors
-     */
+	 */
 	public static DifferenceDescription isTextMatchingTemplate(String template, String compareText) throws SpdxCompareException {
 		CompareTemplateOutputHandler compareTemplateOutputHandler;
 		try {

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -223,7 +223,7 @@ public class LicenseCompareHelper {
 	 * @return {@code true} if the text contains a single token,
 	 *         {@code false} otherwise.
 	 */
-	public static boolean isSingleTokenString(String text) {
+	public static boolean isSingleTokenString(@Nullable String text) {
 		if (text == null) {
 			return false;
 		}

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Collection;
+import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -206,7 +207,7 @@ public class LicenseCompareHelper {
 	 *         or {@code null} if none is found.
 	 */
 	public static @Nullable String getFirstLicenseToken(@Nullable String text) {
-		if (text == null) {
+		if (text == null || text.isEmpty()) {
 			return null;
 		}
 		String textToTokenize = LicenseTextHelper.normalizeText(LicenseTextHelper.replaceMultWord(LicenseTextHelper.replaceSpaceComma(
@@ -233,7 +234,7 @@ public class LicenseCompareHelper {
 	 *         {@code false} otherwise.
 	 */
 	public static boolean isSingleTokenString(@Nullable String text) {
-		if (text == null) {
+		if (text == null || text.isEmpty()) {
 			return false;
 		}
 		if (text.contains("\n")) {
@@ -250,7 +251,7 @@ public class LicenseCompareHelper {
 				}
 			}
 		}
-		return true;
+		return found;
 	}
 
 	/**

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -227,8 +227,9 @@ public class LicenseCompareHelper {
 	/**
 	 * Check whether the given text contains only a single token
 	 * <p>
-	 * A single token string is a string that contains zero or one token as
-	 * identified by the {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
+	 * A single token string is a string that contains zero or one
+	 * non-whitspace token as identified by the
+	 * {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
 	 * </p>
 	 *
 	 * @param text The text to test.
@@ -240,16 +241,17 @@ public class LicenseCompareHelper {
 			return true; // zero tokens is considered a single token string
 		}
 		Matcher m = LicenseTextHelper.TOKEN_SPLIT_PATTERN.matcher(text);
-		int nonWhitespaceTokenCount = 0;
+		boolean found = false;
 		while (m.find()) {
 			if (!m.group(1).trim().isEmpty()) {
-				nonWhitespaceTokenCount++;
-				if (nonWhitespaceTokenCount > 1) {
-					return false; // more than one token
+				if (found) {
+					return false; // more than one token found
+				} else {
+					found = true; // first token found
 				}
 			}
 		}
-		return true; // either no tokens or one token
+		return true; // either no tokens or only one token found
 	}
 
 	/**

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -227,31 +227,32 @@ public class LicenseCompareHelper {
 	/**
 	 * Check whether the given text contains only a single token
 	 * <p>
-	 * A single token string is a string that contains zero or one
-	 * non-whitspace token as identified by the
-	 * {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
+	 * A single token string is a string that contains zero or one token,
+	 * as identified by the {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
+	 * Whitespace and punctuation such as dots, commas, question marks,
+	 * and quotation marks are ignored.
 	 * </p>
 	 *
 	 * @param text The text to test.
-	 * @return {@code true} if the text contains zero one token,
+	 * @return {@code true} if the text contains zero or one token,
 	 *         {@code false} otherwise.
 	 */
 	public static boolean isSingleTokenString(@Nullable String text) {
 		if (text == null || text.isEmpty()) {
-			return true; // zero tokens is considered a single token string
+			return true; // Zero tokens is considered a single token string
 		}
 		Matcher m = LicenseTextHelper.TOKEN_SPLIT_PATTERN.matcher(text);
 		boolean found = false;
 		while (m.find()) {
 			if (!m.group(1).trim().isEmpty()) {
 				if (found) {
-					return false; // more than one token found
+					return false; // More than one eligible token found
 				} else {
-					found = true; // first token found
+					found = true; // First eligible token found
 				}
 			}
 		}
-		return true; // either no tokens or only one token found
+		return true; // Zero or one eligible token found
 	}
 
 	/**

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -181,12 +181,25 @@ public class LicenseCompareHelper {
         }
         // ignore
     }
-	
-	/*
-	 * @param text text to test
-	 * @return the first token in the license text
+
+	/**
+	 * Return the first license token found in the given text
+	 * <p>
+	 * The method normalizes the input text, removes comment characters,
+	 * and splits it into tokens
+	 * using {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
+	 * It returns the first non-empty token found,
+	 * or {@code null} if no such token exists.
+	 * </p>
+	 *
+	 * @param text The license text to extract the first token from.
+	 * @return The first non-empty token as a {@link String},
+	 *         or {@code null} if none is found.
 	 */
 	public static String getFirstLicenseToken(String text) {
+		if (text == null) {
+			return null;
+		}
 		String textToTokenize = LicenseTextHelper.normalizeText(LicenseTextHelper.replaceMultWord(LicenseTextHelper.replaceSpaceComma(
 				LicenseTextHelper.removeLineSeparators(removeCommentChars(text))))).toLowerCase();
 		Matcher m = LicenseTextHelper.TOKEN_SPLIT_PATTERN.matcher(textToTokenize);
@@ -197,12 +210,23 @@ public class LicenseCompareHelper {
 		}
 		return null;
 	}
-	
+
 	/**
-	 * @param text text to test
-	 * @return true if the text contains a single token
+	 * Check whether the given text contains only a single token
+	 * <p>
+	 * A single token string is defined as a non-null string that does not
+	 * contain any newline characters and contains exactly one non-empty token
+	 * as identified by the {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
+	 * </p>
+	 *
+	 * @param text The text to test.
+	 * @return {@code true} if the text contains a single token,
+	 *         {@code false} otherwise.
 	 */
 	public static boolean isSingleTokenString(String text) {
+		if (text == null) {
+			return false;
+		}
 		if (text.contains("\n")) {
 			return false;
 		}

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -196,7 +196,7 @@ public class LicenseCompareHelper {
 	 * @return The first non-empty token as a {@link String},
 	 *         or {@code null} if none is found.
 	 */
-	public static String getFirstLicenseToken(String text) {
+	public static @Nullable String getFirstLicenseToken(@Nullable String text) {
 		if (text == null) {
 			return null;
 		}

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -542,19 +542,26 @@ public class LicenseCompareHelperTest extends TestCase {
 	}
 
 	public void testisSingleTokenString() {
-		assertTrue(LicenseCompareHelper.isSingleTokenString("token"));
-		assertTrue(LicenseCompareHelper.isSingleTokenString(" token "));
-		assertTrue(LicenseCompareHelper.isSingleTokenString(" \n token "));
+		assertTrue(LicenseCompareHelper.isSingleTokenString(null));
+		assertTrue(LicenseCompareHelper.isSingleTokenString(""));
+		assertTrue(LicenseCompareHelper.isSingleTokenString(" "));
+		assertTrue(LicenseCompareHelper.isSingleTokenString("\n"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("'"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString(" '"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("' "));
+		assertTrue(LicenseCompareHelper.isSingleTokenString("''"));
+		assertTrue(LicenseCompareHelper.isSingleTokenString("token"));
+		assertTrue(LicenseCompareHelper.isSingleTokenString(" token"));
+		assertTrue(LicenseCompareHelper.isSingleTokenString("token\n"));
+		assertTrue(LicenseCompareHelper.isSingleTokenString("\ntoken"));
+		assertTrue(LicenseCompareHelper.isSingleTokenString(" \n token "));
+		assertTrue(LicenseCompareHelper.isSingleTokenString("'''token"));
+		assertTrue(LicenseCompareHelper.isSingleTokenString("token'''"));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("a and"));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("a\nand"));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("a and  "));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("  a and"));
-		assertFalse(LicenseCompareHelper.isSingleTokenString("\n"));
-		assertFalse(LicenseCompareHelper.isSingleTokenString(""));
-		assertFalse(LicenseCompareHelper.isSingleTokenString(null));
+		assertFalse(LicenseCompareHelper.isSingleTokenString("  a.and"));
 	}
 
 	public void regressionTestMatchingGpl20Only() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException {

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -539,18 +539,19 @@ public class LicenseCompareHelperTest extends TestCase {
 		Map<String, String> xlationMap = new HashMap<>();;
 		assertTrue(LicenseCompareHelper.isLicenseEqual(lic3, lic4, xlationMap));
 		assertFalse(LicenseCompareHelper.isLicenseEqual(lic4, lic2, xlationMap));
-	}	
-	
-	
+	}
+
 	public void testisSingleTokenString() {
+		assertTrue(LicenseCompareHelper.isSingleTokenString(""));
 		assertTrue(LicenseCompareHelper.isSingleTokenString(" token "));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("'"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString(" '"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("' "));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("a and"));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("a\nand"));
+		assertFalse(LicenseCompareHelper.isSingleTokenString(null));
 	}
-	
+
 	public void regressionTestMatchingGpl20Only() throws IOException, InvalidSPDXAnalysisException, SpdxCompareException {
 		String compareText = UnitTestHelper.fileToText(GPL_2_TEXT);
 		DifferenceDescription result = LicenseCompareHelper.isTextStandardLicense(LicenseInfoFactory.getListedLicenseById("GPL-2.0-only"), compareText);
@@ -568,11 +569,16 @@ public class LicenseCompareHelperTest extends TestCase {
 			assertTrue(result[3].startsWith("GPL-2"));
 		}
 	}
-	
+
 	public void testFirstLicenseToken() {
 		assertEquals("first", LicenseCompareHelper.getFirstLicenseToken("   first,token that is needed\nnext"));
+		assertEquals("first", LicenseCompareHelper.getFirstLicenseToken("// first,second"));
+		assertNull(LicenseCompareHelper.getFirstLicenseToken(null));
+		assertNull(LicenseCompareHelper.getFirstLicenseToken(""));
+		assertNull(LicenseCompareHelper.getFirstLicenseToken("  <!-- -->"));
+		assertNull(LicenseCompareHelper.getFirstLicenseToken("# "));
 	}
-	
+
 	@SuppressWarnings("unused")
 	private String stringCharToUnicode(String s, int location) {
 		return "\\u" + Integer.toHexString(s.charAt(location) | 0x10000).substring(1);

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -552,9 +552,11 @@ public class LicenseCompareHelperTest extends TestCase {
 		assertTrue(LicenseCompareHelper.isSingleTokenString("''"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("token"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString(" token"));
+		assertTrue(LicenseCompareHelper.isSingleTokenString(" token "));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("token\n"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("\ntoken"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString(" \n token "));
+		assertTrue(LicenseCompareHelper.isSingleTokenString(":;token?"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("'''token"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("token'''"));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("a and"));

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -542,13 +542,18 @@ public class LicenseCompareHelperTest extends TestCase {
 	}
 
 	public void testisSingleTokenString() {
-		assertTrue(LicenseCompareHelper.isSingleTokenString(""));
+		assertTrue(LicenseCompareHelper.isSingleTokenString("token"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString(" token "));
+		assertTrue(LicenseCompareHelper.isSingleTokenString(" \n token "));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("'"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString(" '"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("' "));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("a and"));
 		assertFalse(LicenseCompareHelper.isSingleTokenString("a\nand"));
+		assertFalse(LicenseCompareHelper.isSingleTokenString("a and  "));
+		assertFalse(LicenseCompareHelper.isSingleTokenString("  a and"));
+		assertFalse(LicenseCompareHelper.isSingleTokenString("\n"));
+		assertFalse(LicenseCompareHelper.isSingleTokenString(""));
 		assertFalse(LicenseCompareHelper.isSingleTokenString(null));
 	}
 


### PR DESCRIPTION
Check if the string input is null in `getFirstLicenseToken` and `isSingleTokenString`

To fix #333
