### PR TITLE
update isSingleToken to return false for null and empty strings

### DIFF
--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -238,8 +238,8 @@ public class LicenseCompareHelper {
 	 *         {@code false} otherwise.
 	 */
 	public static boolean isSingleTokenString(@Nullable String text) {
-		if (text == null || text.isEmpty()) {
-			return true; // Zero tokens is considered a single token string
+		if (text == null || text.trim().isEmpty()) {
+			return false;
 		}
 		Matcher m = LicenseTextHelper.TOKEN_SPLIT_PATTERN.matcher(text);
 		boolean found = false;

--- a/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
+++ b/src/main/java/org/spdx/utility/compare/LicenseCompareHelper.java
@@ -227,14 +227,14 @@ public class LicenseCompareHelper {
 	/**
 	 * Check whether the given text contains only a single token
 	 * <p>
-	 * A single token string is a string that contains zero or one token,
+	 * A single token string is a string that contains exactly one token,
 	 * as identified by the {@link LicenseTextHelper#TOKEN_SPLIT_PATTERN}.
 	 * Whitespace and punctuation such as dots, commas, question marks,
 	 * and quotation marks are ignored.
 	 * </p>
 	 *
 	 * @param text The text to test.
-	 * @return {@code true} if the text contains zero or one token,
+	 * @return {@code true} if the text contains exactly one token,
 	 *         {@code false} otherwise.
 	 */
 	public static boolean isSingleTokenString(@Nullable String text) {

--- a/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
+++ b/src/test/java/org/spdx/utility/compare/LicenseCompareHelperTest.java
@@ -542,10 +542,10 @@ public class LicenseCompareHelperTest extends TestCase {
 	}
 
 	public void testisSingleTokenString() {
-		assertTrue(LicenseCompareHelper.isSingleTokenString(null));
-		assertTrue(LicenseCompareHelper.isSingleTokenString(""));
-		assertTrue(LicenseCompareHelper.isSingleTokenString(" "));
-		assertTrue(LicenseCompareHelper.isSingleTokenString("\n"));
+		assertFalse(LicenseCompareHelper.isSingleTokenString(null));
+		assertFalse(LicenseCompareHelper.isSingleTokenString(""));
+		assertFalse(LicenseCompareHelper.isSingleTokenString(" "));
+		assertFalse(LicenseCompareHelper.isSingleTokenString("\n"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("'"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString(" '"));
 		assertTrue(LicenseCompareHelper.isSingleTokenString("' "));


### PR DESCRIPTION
Returning true causes index out of bounds errors in other libraries.

Note: my previous analysis that it should return true was incorrect.