### PR TITLE
Improve license parsing error messages

### DIFF
--- a/src/main/java/org/spdx/utility/license/LicenseExpressionParser.java
+++ b/src/main/java/org/spdx/utility/license/LicenseExpressionParser.java
@@ -504,6 +504,10 @@ public class LicenseExpressionParser {
 			return localLicense;
 		} else if (LicenseInfoFactory.isSpdxListedExceptionId(token)) {
 			throw new LicenseParserException(String.format("Unexpected listed license exception %s.  Must be a listed license or a LicenseRef", token));
+		} else if (SpdxConstantsCompatV2.NOASSERTION_VALUE.equals(token)) {
+			throw new LicenseParserException("NOASSERTION is currently not allowed in a complex license expression");
+		} else if (SpdxConstantsCompatV2.NONE_VALUE.equals(token)) {
+			throw new LicenseParserException("NONE is currently not allowed in a complex license expression");
 		} else {
 			throw new LicenseParserException(String.format("Unknown license %s.  Must be a listed license or have the syntax %s", token, SpdxConstantsCompatV2.LICENSE_ID_PATTERN));
 		}
@@ -590,6 +594,10 @@ public class LicenseExpressionParser {
 			return localLicense;
 		} else if (LicenseInfoFactory.isSpdxListedExceptionId(token)) {
 			throw new LicenseParserException(String.format("Unexpected listed license exception %s.  Must be a listed license or a LicenseRef", token));
+		} else if (SpdxConstantsCompatV2.NOASSERTION_VALUE.equals(token)) {
+			throw new LicenseParserException("NOASSERTION is currently not allowed in a complex license expression");
+		} else if (SpdxConstantsCompatV2.NONE_VALUE.equals(token)) {
+			throw new LicenseParserException("NONE is currently not allowed in a complex license expression");
 		} else {
 			throw new LicenseParserException(String.format("Unknown license %s.  Must be a listed license or have the syntax %s", token, SpdxConstantsCompatV2.LICENSE_ID_PATTERN));
 		}

--- a/src/test/java/org/spdx/library/LicenseInfoFactoryTest.java
+++ b/src/test/java/org/spdx/library/LicenseInfoFactoryTest.java
@@ -32,6 +32,7 @@ import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicense;
 import org.spdx.library.model.v3_0_1.expandedlicensing.NoAssertionLicense;
 import org.spdx.library.model.v3_0_1.expandedlicensing.NoneLicense;
 import org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo;
+import org.spdx.library.model.v3_0_1.simplelicensing.InvalidLicenseExpression;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
 import org.spdx.storage.simple.InMemSpdxStore;
@@ -161,7 +162,7 @@ public class LicenseInfoFactoryTest extends TestCase {
 	public void testDifferentLicenseOrder() throws InvalidSPDXAnalysisException {
 		AnyLicenseInfo order1 = LicenseInfoFactory.parseSPDXLicenseString("(LicenseRef-14 AND LicenseRef-5 AND LicenseRef-6 AND LicenseRef-15 AND LicenseRef-3 AND LicenseRef-12 AND LicenseRef-4 AND LicenseRef-13 AND LicenseRef-10 AND LicenseRef-9 AND LicenseRef-11 AND LicenseRef-7 AND LicenseRef-8 AND LGPL-2.1+ AND LicenseRef-1 AND LicenseRef-2 AND LicenseRef-0 AND GPL-2.0+ AND GPL-2.0 AND LicenseRef-17 AND LicenseRef-16 AND BSD-3-Clause-Clear)");
 		AnyLicenseInfo order2 = LicenseInfoFactory.parseSPDXLicenseString("(LicenseRef-14 AND LicenseRef-5 AND LicenseRef-6 AND LicenseRef-15 AND LicenseRef-12 AND LicenseRef-3 AND LicenseRef-13 AND LicenseRef-4 AND LicenseRef-10 AND LicenseRef-9 AND LicenseRef-11 AND LicenseRef-7 AND LicenseRef-8 AND LGPL-2.1+ AND LicenseRef-1 AND LicenseRef-2 AND LicenseRef-0 AND GPL-2.0+ AND GPL-2.0 AND LicenseRef-17 AND BSD-3-Clause-Clear AND LicenseRef-16)");
-		assertTrue(order1.equals(order2));
+        assertEquals(order1, order2);
 		assertTrue(order1.equivalent(order2));
 	}
 
@@ -171,4 +172,14 @@ public class LicenseInfoFactoryTest extends TestCase {
 		AnyLicenseInfo result = LicenseInfoFactory.parseSPDXLicenseString(lowerCaseCecil);
 		assertEquals(COMPLEX_LICENSE, result);
 	}
+
+	public void testInvalid() throws InvalidSPDXAnalysisException {
+		AnyLicenseInfo result = LicenseInfoFactory.parseSPDXLicenseString("MIT AND NOT Apache-2.0");
+		assertTrue(result instanceof InvalidLicenseExpression);
+		List<String> verify = result.verify();
+		assertEquals(1, verify.size());
+		assertTrue(verify.get(0).contains("NOT"));
+		assertTrue(verify.get(0).contains("Unknown license"));
+	}
+
 }

--- a/src/test/java/org/spdx/library/LicenseInfoFactoryTestV2.java
+++ b/src/test/java/org/spdx/library/LicenseInfoFactoryTestV2.java
@@ -159,4 +159,13 @@ public class LicenseInfoFactoryTestV2 extends TestCase {
 		result = LicenseInfoFactory.parseSPDXLicenseStringCompatV2(lowerCaseCecil);
 		assertEquals(COMPLEX_LICENSE, result);
 	}
+
+	public void testInvalidV2() throws InvalidSPDXAnalysisException {
+		AnyLicenseInfo result = LicenseInfoFactory.parseSPDXLicenseStringCompatV2("MIT AND NOT Apache-2.0");
+		assertTrue(result instanceof org.spdx.library.model.v2.license.InvalidLicenseExpression);
+		List<String> verify = result.verify();
+		assertEquals(1, verify.size());
+		assertTrue(verify.get(0).contains("NOT"));
+		assertTrue(verify.get(0).contains("Unknown license"));
+	}
 }


### PR DESCRIPTION
Fixes #338

Dependes on updates to the SPDX Models versions 2 and 3 which add a new class "InvalidLicenseExpression" which is used to produce the errors.

This changes the behavior of the license parser from throwing an exception to returning an InvalidLicenseExpression where the verify routine will return the error message.