### PR TITLE
Spdx2to3Converter: return null for "NONE" or "NOASSERTION" Agents

### DIFF
--- a/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
+++ b/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
@@ -346,6 +346,10 @@ public class Spdx2to3Converter implements ISpdxConverter {
 		Objects.requireNonNull(idPrefix, "Creation info must have an idPrefix to accurately generate SPDX IDs");
 		Matcher matcher = SPDX_2_CREATOR_PATTERN.matcher(spdx2personOrgString);
 		if (!matcher.matches()) {
+			// return null for NOASSERTION and NONE
+			if ("NOASSERTION".equals(spdx2personOrgString) || "NONE".equals(spdx2personOrgString)) {
+				return null;
+			}
 			// return a generic Agent
 			Agent agent = (Agent)SpdxModelClassFactoryV3.getModelObject(creationInfo.getModelStore(), 
 					creationInfo.getIdPrefix() + creationInfo.getModelStore().getNextId(IdType.SpdxId),

--- a/src/test/java/org/spdx/library/conversion/Spdx2to3ConverterTest.java
+++ b/src/test/java/org/spdx/library/conversion/Spdx2to3ConverterTest.java
@@ -1951,5 +1951,29 @@ public class Spdx2to3ConverterTest {
 		assertTrue(expected.isEmpty());
 		assertEquals(ands.toString(), result.getLicenseExpression());
 	}
+	
+	@Test
+	public void testPackageSupplierNoAssertionAndNone() throws InvalidSPDXAnalysisException {
+		CreationInfo testCreationInfo = Spdx2to3Converter.convertCreationInfo(
+				new SpdxCreatorInformation(fromModelStore, DOCUMENT_URI, 
+						fromModelStore.getNextId(IdType.Anonymous), copyManager, true)
+					.setCreated("2010-01-29T18:30:22Z"),
+				toModelStore, DEFAULT_PREFIX);
+		
+		// "NOASSERTION" agent string
+		Agent resultNoAssertion = Spdx2to3Converter.stringToAgent("NOASSERTION", testCreationInfo);
+		assertNull("stringToAgent should return null for NOASSERTION value", resultNoAssertion);
+		
+		// "NONE" agent string
+		Agent resultNone = Spdx2to3Converter.stringToAgent("NONE", testCreationInfo);
+		assertNull("stringToAgent should return null for NONE value", resultNone);
+		
+		// Valid Person agent string
+		String personCreator = SpdxConstantsCompatV2.CREATOR_PREFIX_PERSON + "John Doe (john@example.com)";
+		Agent resultPerson = Spdx2to3Converter.stringToAgent(personCreator, testCreationInfo);
+		assertNotNull("stringToAgent should return an Agent for valid Person format", resultPerson);
+		assertTrue("Result should be a Person", resultPerson instanceof Person);
+		assertEquals("John Doe", resultPerson.getName().get());
+	}
 
 }


### PR DESCRIPTION
The javadocs for `Spdx2to3Converter.stringToAgent()` say:

> 	 * @return Agent based on parsing the spdx2personOrgString - if NONE or NOASSERTION is the string value, the null is returned

But null is not being returned for NONE or NOASSERTION strings, so the method is creating a new "Agent" node for each time these agent values are needed, e.g. for a "suppliedBy" value:

``` json
...
  }, {
    "spdxId" : "https://org.spdx.spdxdata/4320c18a-dbd2-49ba-9ca7-c0e5230700a6/SPDXRef-gnrtd75",
    "type" : "Agent",
    "name" : "NOASSERTION",
    "creationInfo" : "_:creationInfo_0"
  }, {
    "spdxId" : "https://org.spdx.spdxdata/4320c18a-dbd2-49ba-9ca7-c0e5230700a6/SPDXRef-gnrtd83",
    "type" : "Agent",
    "name" : "NOASSERTION",
    "creationInfo" : "_:creationInfo_0"
  }, {
    "spdxId" : "https://org.spdx.spdxdata/4320c18a-dbd2-49ba-9ca7-c0e5230700a6/SPDXRef-gnrtd91",
    "type" : "Agent",
    "name" : "NOASSERTION",
    "creationInfo" : "_:creationInfo_0"
  }, {
...
```

This fix returns null instead so the convert won't create the "Agent" nodes.