### PR TITLE
Change licenses field from final to non-final

### DIFF
--- a/src/main/java/org/spdx/storage/listedlicense/LicenseJsonTOC.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseJsonTOC.java
@@ -160,7 +160,7 @@ public class LicenseJsonTOC {
 	
 
 	private String licenseListVersion;
-	private final List<LicenseJson> licenses;
+	private List<LicenseJson> licenses;
 	private String releaseDate;
 
 	public LicenseJsonTOC(String version, String releaseDate) {


### PR DESCRIPTION
Fixes #409

The JSON deserializer will modify the `licenses` property - it should not be marked as final for this reason.