### PR TITLE
Add correct license expression in invalid license expressions

### DIFF
--- a/src/main/java/org/spdx/library/LicenseInfoFactory.java
+++ b/src/main/java/org/spdx/library/LicenseInfoFactory.java
@@ -249,6 +249,7 @@ public class LicenseInfoFactory {
 				InvalidLicenseExpression retval = new InvalidLicenseExpression(store, store.getNextId(IModelStore.IdType.Anonymous),
 						copyManager, true, customLicensePrefix);
 				retval.setMessage(e.getMessage());
+				retval.setLicenseExpression(licenseString);
 				return retval;
 			} catch (InvalidSPDXAnalysisException e1) {
 				throw new RuntimeException(e1);
@@ -258,6 +259,7 @@ public class LicenseInfoFactory {
 				InvalidLicenseExpression retval = new InvalidLicenseExpression(store, store.getNextId(IModelStore.IdType.Anonymous),
 						copyManager, true, customLicensePrefix);
 				retval.setMessage(String.format("Unexpected SPDX error parsing license string: %s", e.getMessage()));
+				retval.setLicenseExpression(licenseString);
 				return retval;
 			} catch (InvalidSPDXAnalysisException e1) {
 				throw new RuntimeException(e1);

--- a/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
+++ b/src/main/java/org/spdx/library/conversion/Spdx2to3Converter.java
@@ -870,7 +870,7 @@ public class Spdx2to3Converter implements ISpdxConverter {
 				toObjectUri, "SimpleLicensing.InvalidLicenseExpression", copyManager, true, defaultUriPrefix);
 		toInvalidLicExpression.setCreationInfo(defaultCreationInfo);
 		toInvalidLicExpression.setMessage(fromInvalidLicenseExpression.getMessage());
-		toInvalidLicExpression.setLicenseExpression(fromInvalidLicenseExpression.getMessage());
+		toInvalidLicExpression.setLicenseExpression(fromInvalidLicenseExpression.getLicenseExpression());
 		return toInvalidLicExpression;
 	}
 	

--- a/src/test/java/org/spdx/utility/license/LicenseExpressionParserTest.java
+++ b/src/test/java/org/spdx/utility/license/LicenseExpressionParserTest.java
@@ -48,6 +48,7 @@ import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicenseException;
 import org.spdx.library.model.v3_0_1.expandedlicensing.OrLaterOperator;
 import org.spdx.library.model.v3_0_1.expandedlicensing.WithAdditionOperator;
 import org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo;
+import org.spdx.library.model.v3_0_1.simplelicensing.InvalidLicenseExpression;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.IModelStore.IdType;
 import org.spdx.storage.simple.InMemSpdxStore;
@@ -183,7 +184,7 @@ public class LicenseExpressionParserTest extends TestCase {
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, 
 				modelStore, DEFAULT_PREFIX, creationInfo,
 				copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -192,7 +193,7 @@ public class LicenseExpressionParserTest extends TestCase {
 		AnyLicenseInfo expected = NON_STD_LICENSES[0];
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, modelStore, 
 				DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 	
 	public void testUninitializedExtractedLicense() throws InvalidSPDXAnalysisException {
@@ -209,7 +210,7 @@ public class LicenseExpressionParserTest extends TestCase {
 		expected.setSubjectLicense(STANDARD_LICENSES[0]);
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, 
 				modelStore, DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -220,14 +221,14 @@ public class LicenseExpressionParserTest extends TestCase {
 		expected.setSubjectExtendableLicense(STANDARD_LICENSES[0]);
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, modelStore, 
 				DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 		parseString = STD_IDS[0]+" WITH " + STD_EXCEPTION_IDS[0];
 		expected = new WithAdditionOperator();
 		expected.setSubjectAddition(STD_LICENSE_EXCEPTIONS[0]);
 		expected.setSubjectExtendableLicense(STANDARD_LICENSES[0]);
 		result = LicenseExpressionParser.parseLicenseExpression(parseString, modelStore, 
 				DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -238,7 +239,7 @@ public class LicenseExpressionParserTest extends TestCase {
 		expected.getMembers().add(NON_STD_LICENSES[0]);
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, 
 				modelStore, DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -249,7 +250,7 @@ public class LicenseExpressionParserTest extends TestCase {
 		expected.getMembers().add(NON_STD_LICENSES[0]);
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, 
 				modelStore, DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -261,7 +262,7 @@ public class LicenseExpressionParserTest extends TestCase {
 				NON_STD_LICENSES[1], STANDARD_LICENSES[2], STANDARD_LICENSES[3]})));
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, modelStore, 
 				DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -273,7 +274,7 @@ public class LicenseExpressionParserTest extends TestCase {
 				NON_STD_LICENSES[1], STANDARD_LICENSES[2], STANDARD_LICENSES[3]})));
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, modelStore, 
 				DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -285,7 +286,7 @@ public class LicenseExpressionParserTest extends TestCase {
 				NON_STD_LICENSES[1], STANDARD_LICENSES[2], STANDARD_LICENSES[3]})));
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, 
 				modelStore, DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -299,7 +300,7 @@ public class LicenseExpressionParserTest extends TestCase {
 				NON_STD_LICENSES[1], dls})));
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, modelStore, 
 				DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 
 
@@ -314,7 +315,7 @@ public class LicenseExpressionParserTest extends TestCase {
 				cls, STANDARD_LICENSES[3]})));
 		AnyLicenseInfo result = LicenseExpressionParser.parseLicenseExpression(parseString, 
 				modelStore, DEFAULT_PREFIX, creationInfo, copyManager, idMap);
-        assertEquals(expected, result);
+		assertTrue(expected.equals(result));
 	}
 	
 	public void testExternalCustomLicense() throws InvalidSPDXAnalysisException {
@@ -404,5 +405,12 @@ public class LicenseExpressionParserTest extends TestCase {
 		assertTrue(result instanceof DisjunctiveLicenseSet);
 		assertTrue(((DisjunctiveLicenseSet)result).getMembers().contains(NON_STD_LICENSES[1]));
 		assertTrue(((DisjunctiveLicenseSet)result).getMembers().contains(STANDARD_LICENSES[1]));
+	}
+
+	public void testInvalidExceptionOnly() throws InvalidSPDXAnalysisException {
+		AnyLicenseInfo result = LicenseInfoFactory.parseSPDXLicenseString(STD_EXCEPTION_IDS[0], modelStore,
+				DEFAULT_PREFIX, creationInfo, copyManager, idMap);
+		assertTrue(result instanceof InvalidLicenseExpression);
+		assertEquals(STD_EXCEPTION_IDS[0], ((InvalidLicenseExpression)result).getLicenseExpression());
 	}
 }

--- a/src/test/java/org/spdx/utility/license/LicenseExpressionParserTestV2.java
+++ b/src/test/java/org/spdx/utility/license/LicenseExpressionParserTestV2.java
@@ -244,6 +244,9 @@ public class LicenseExpressionParserTestV2 extends TestCase {
 	}
 
 	public void testInvalidExceptionOnly() throws InvalidSPDXAnalysisException {
+        # "389-exception" is a valid license exception,
+        # but a license expression has to be presented with a license,
+        # to form a valid license expression.
 		AnyLicenseInfo result = LicenseInfoFactory.parseSPDXLicenseStringCompatV2("389-exception");
 		assertTrue(result instanceof InvalidLicenseExpression);
 		assertEquals("389-exception", ((InvalidLicenseExpression)result).getLicenseExpression());

--- a/src/test/java/org/spdx/utility/license/LicenseExpressionParserTestV2.java
+++ b/src/test/java/org/spdx/utility/license/LicenseExpressionParserTestV2.java
@@ -31,16 +31,7 @@ import org.spdx.library.model.v2.GenericModelObject;
 import org.spdx.library.model.v2.SpdxConstantsCompatV2;
 import org.spdx.library.model.v2.SpdxDocument;
 import org.spdx.library.model.v2.enumerations.ChecksumAlgorithm;
-import org.spdx.library.model.v2.license.AnyLicenseInfo;
-import org.spdx.library.model.v2.license.ConjunctiveLicenseSet;
-import org.spdx.library.model.v2.license.DisjunctiveLicenseSet;
-import org.spdx.library.model.v2.license.ExternalExtractedLicenseInfo;
-import org.spdx.library.model.v2.license.ExtractedLicenseInfo;
-import org.spdx.library.model.v2.license.LicenseException;
-import org.spdx.library.model.v2.license.ListedLicenseException;
-import org.spdx.library.model.v2.license.OrLaterOperator;
-import org.spdx.library.model.v2.license.SpdxListedLicense;
-import org.spdx.library.model.v2.license.WithExceptionOperator;
+import org.spdx.library.model.v2.license.*;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.simple.InMemSpdxStore;
 
@@ -250,5 +241,11 @@ public class LicenseExpressionParserTestV2 extends TestCase {
 		}
 		assertTrue(foundLicenseRef);
 		assertTrue(foundMit);
+	}
+
+	public void testInvalidExceptionOnly() throws InvalidSPDXAnalysisException {
+		AnyLicenseInfo result = LicenseInfoFactory.parseSPDXLicenseStringCompatV2("389-exception");
+		assertTrue(result instanceof InvalidLicenseExpression);
+		assertEquals("389-exception", ((InvalidLicenseExpression)result).getLicenseExpression());
 	}
 }


### PR DESCRIPTION
Also adds unit tests for invalid license expressions when just an exception ID is found without a "with" clause for the V2 parser.