### PR TITLE
Add methods to sort license JSON and license JSON TOC

### DIFF
--- a/src/main/java/org/spdx/storage/listedlicense/ExceptionJsonTOC.java
+++ b/src/main/java/org/spdx/storage/listedlicense/ExceptionJsonTOC.java
@@ -283,4 +283,11 @@ public class ExceptionJsonTOC {
 		this.releaseDate = releaseDate;
 	}
 
+	/**
+	 * Sort the exceptions list by licenseExceptionId.
+	 */
+	public void sort() {
+		exceptions.sort((e1, e2) -> e1.getLicenseExceptionId().compareToIgnoreCase(e2.getLicenseExceptionId()));
+	}
+
 }

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseJson.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseJson.java
@@ -19,6 +19,7 @@ package org.spdx.storage.listedlicense;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -556,5 +557,15 @@ public class LicenseJson {
 			}
 		});
 		return retval;
+	}
+
+	/**
+	 * Sort the crossRef list by order, with URL as a secondary sort key for
+	 * entries with no order set.
+	 */
+	public void sortCrossRef() {
+		crossRef.sort(Comparator
+				.comparingInt((CrossRefJson c) -> c.order != null ? c.order : Integer.MAX_VALUE)
+				.thenComparing(c -> c.url != null ? c.url : ""));
 	}
 }

--- a/src/main/java/org/spdx/storage/listedlicense/LicenseJsonTOC.java
+++ b/src/main/java/org/spdx/storage/listedlicense/LicenseJsonTOC.java
@@ -251,6 +251,13 @@ public class LicenseJsonTOC {
 		this.releaseDate = releaseDate;
 	}
 
+	/**
+	 * Sort the licenses list by licenseId.
+	 */
+	public void sort() {
+		licenses.sort((l1, l2) -> l1.getLicenseId().compareToIgnoreCase(l2.getLicenseId()));
+	}
+
 	protected static String toAbsoluteURL(String relURL) {
 		String retval = relURL.startsWith("./") ? relURL.substring(2) : relURL;
 		return SpdxConstantsCompatV2.LISTED_LICENSE_URL + retval;


### PR DESCRIPTION
To get more stable JSON output

- ExceptionJsonTOC.sort() -- same logic as in https://github.com/spdx/LicenseListPublisher/pull/149
- LicenseJsonTOC.sort() -- same logic as in https://github.com/spdx/LicenseListPublisher/pull/149
- LicenseJson.sortCrossRef() -- will be used by https://github.com/spdx/LicenseListPublisher/pull/244

> [!NOTE]
> For LicenseListPublisher, to sort `crossRef` in the JSON output, apply https://github.com/spdx/LicenseListPublisher/pull/244 after the change is this PR is released.