### PR TITLE
Add SpotBugs analysis check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         fi
 
   spotbugs:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,22 +15,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
     - name: Set up JDK 17
-      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
       with:
         distribution: 'temurin'
         java-version: 17
     - name: Cache SonarCloud packages
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Cache Maven packages
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -44,4 +44,43 @@ jobs:
            mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
         else
            mvn --batch-mode --update-snapshots verify
+        fi
+
+  spotbugs:
+    if: github.event_name == 'pull_request'
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - name: Set up JDK 17
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
+      with:
+        distribution: 'temurin'
+        java-version: 17
+    - name: Cache Maven packages
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run SpotBugs analysis
+      run: mvn --batch-mode --update-snapshots compile com.github.spotbugs:spotbugs-maven-plugin:spotbugs
+    - name: Upload SpotBugs SARIF report
+      if: always()
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@bb16b9baa2ec4010b29f5c606d57d01190139edd  # v4.37.1
+      with:
+        sarif_file: target/spotbugsSarif.json
+        category: spotbugs
+    - name: Fail job if SpotBugs found bugs
+      run: |
+        bug_count=$(grep -o '<BugInstance' target/spotbugsXml.xml | wc -l | tr -d '[:space:]' || true)
+        if [ "$bug_count" -gt 0 ]; then
+          echo "::error::SpotBugs found $bug_count bug(s). See the Checks/Security tab for annotated details."
+          exit 1
         fi

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,18 @@
 				<version>${dependency-check-maven.version}</version>
 			</plugin>
 			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.10.3.0</version>
+				<configuration>
+					<effort>Max</effort>
+					<threshold>High</threshold>
+					<xmlOutput>true</xmlOutput>
+					<sarifOutput>true</sarifOutput>
+					<failOnError>true</failOnError>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
 				<version>3.6.1</version>
@@ -339,9 +351,13 @@
 	<reporting>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.10.3.0</version>
+				<configuration>
+					<effort>Max</effort>
+					<threshold>High</threshold>
+				</configuration>
 			</plugin>
 		</plugins>
 	</reporting>


### PR DESCRIPTION
Adds a `spotbugs` job to the `build.yml` workflow:
  - Runs SpotBugs analysis (`effort=Max`, `threshold=High`) (SpotBugs is a fork of FindBugs)
  - Fails the job if any bug is found

In `pom.xml`, replaces the unmaintained `findbugs-maven-plugin` reporting entry with `spotbugs-maven-plugin`

Choose threshold=High at this pointm as Medium will report too many errors. We can change this later.

This PR will failed until we fix all bugs reported by SpotBugs (currently 4 of them).

To resolve #210