### PR TITLE
Make LICENSE_ID_PATTERN_GENERATED final

### DIFF
--- a/src/main/java/org/spdx/storage/simple/InMemSpdxStore.java
+++ b/src/main/java/org/spdx/storage/simple/InMemSpdxStore.java
@@ -64,7 +64,7 @@ public class InMemSpdxStore implements IModelStore {
 	/**
 	 * Pattern for the generated license ID
 	 */
-	public static Pattern LICENSE_ID_PATTERN_GENERATED =
+	public static final Pattern LICENSE_ID_PATTERN_GENERATED =
 			Pattern.compile(".*"+SpdxConstantsCompatV2.NON_STD_LICENSE_ID_PRENUM+GENERATED+"(\\d+)$");	// Pattern for generated license IDs
 
 	static Pattern DOCUMENT_ID_PATTERN_GENERATED = Pattern.compile(".*"+SpdxConstantsCompatV2.EXTERNAL_DOC_REF_PRENUM+GENERATED+"(\\d+)$");


### PR DESCRIPTION
- `InMemSpdxStore.LICENSE_ID_PATTERN_GENERATED` is a `public static Pattern` that is never reassigned after initialization
- Marks it `final`, fixing SpotBugs `MS_SHOULD_BE_FINAL` (one of the 4 pre-existing findings surfaced by #434)