### PR TITLE
Handle race condition when insert id to list

### DIFF
--- a/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
+++ b/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
@@ -242,8 +242,11 @@ public class StoredTypedItem extends TypedValue {
 			List<Object> list = idValueMap.get(id);
 			if (list == null) {
 				// handle the very small window where this may have gotten removed
-				list = new ArrayList<>();
-				idValueMap.putIfAbsent(id, list);
+				List<Object> newList = new ArrayList<>();
+				List<Object> existingList = idValueMap.putIfAbsent(id, newList);
+				// another thread may have won the race to insert;
+				// use whichever list actually ended up in the map
+				list = existingList != null ? existingList : newList;
 			}
 			return list.add(value);
 		} catch (Exception ex) {

--- a/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
+++ b/src/main/java/org/spdx/storage/simple/StoredTypedItem.java
@@ -238,16 +238,7 @@ public class StoredTypedItem extends TypedValue {
 			} else {
 				id = NO_ID_ID;
 			}
-			idValueMap.putIfAbsent(id, new ArrayList<>());
-			List<Object> list = idValueMap.get(id);
-			if (list == null) {
-				// handle the very small window where this may have gotten removed
-				List<Object> newList = new ArrayList<>();
-				List<Object> existingList = idValueMap.putIfAbsent(id, newList);
-				// another thread may have won the race to insert;
-				// use whichever list actually ended up in the map
-				list = existingList != null ? existingList : newList;
-			}
+			List<Object> list = idValueMap.computeIfAbsent(id, key -> new ArrayList<>());
 			return list.add(value);
 		} catch (Exception ex) {
 			throw new SpdxInvalidTypeException("Invalid list type for "+propertyDescriptor);


### PR DESCRIPTION
Replace the multi-step check-and-create sequence with a single, uninterruptible call to `ConcurrentHashMap.computeIfAbsent` (follows usage elsewhere in this project).

Fixes SpotBugs `RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED` from #434
